### PR TITLE
introduce way of loosening checks when testsuite not run standalone

### DIFF
--- a/tests/cypress/common/tests.js
+++ b/tests/cypress/common/tests.js
@@ -1,6 +1,11 @@
 /* Copyright (c) 2020 Red Hat, Inc. */
 /* Copyright Contributors to the Open Cluster Management project */
 
+// BEWARE: The execution if this test is altered by an environment variable
+// STANDALONE_TESTSUITE_EXECUTION (resp. CYPRESS_STANDALONE_TESTSUITE_EXECUTION)
+// when set to 'FALSE', some checks are loosened due to possible conflicts with
+// other tests running in the environment
+
 /// <reference types="cypress" />
 import { getDefaultSubstitutionRules, getViolationsPerPolicy, getViolationsCounter,
          getClusterViolationsCounterAndPolicyList } from './views'
@@ -15,11 +20,13 @@ export const test_genericPolicyGovernance = (confFilePolicy, confFileViolationsI
   // policy-config is used for policy creation and validation
   const confPolicies = getConfigObject(confFilePolicy, 'yaml', substitutionRules)
 
-  // first check there are no policies, otherwise numbers won't match
-  it('Verify there are no policies present', () => {
-    cy.get('div.no-resource')  // there should be no-resource element
-      .get('.grc-view-by-policies-table').should('not.exist')  // there should not be policy table
-  })
+  if (Cypress.env('STANDALONE_TESTSUITE_EXECUTION') !== 'FALSE') {
+    // first check there are no policies, otherwise numbers won't match
+    it('Verify there are no policies present', () => {
+      cy.get('div.no-resource')  // there should be no-resource element
+        .get('.grc-view-by-policies-table').should('not.exist')  // there should not be policy table
+   })
+  }
 
   for (const policyName in confPolicies) {
 
@@ -74,16 +81,25 @@ export const test_genericPolicyGovernance = (confFilePolicy, confFileViolationsI
     // BEWARE: The check would only work if there were no other policies present on the cluster
     // if this is not the case, avoid passing violationCounter and violatedPolicies to
     // waitForClusterViolationsStatus() and verifyClusterViolationsInListing() functions below
+    // Currently this is controlled using STANDALONE_TESTSUITE_EXECUTION variable
     it('Wait for cluster violation status to become available', () => {
       // switch to the Clusters tab
       cy.get('#grc-cluster-view').click()
-        .waitForClusterViolationsStatus(clusterName, violationCounter)
-        //.waitForClusterViolationsStatus(clusterName)
+        .then(() => {
+          if (Cypress.env('STANDALONE_TESTSUITE_EXECUTION') !== 'FALSE') {
+            cy.waitForClusterViolationsStatus(clusterName, violationCounter)
+          } else {
+            cy.waitForClusterViolationsStatus(clusterName)
+          }
+        })
     })
 
     it(`Check cluster ${clusterName} violations`, () => {
-      cy.verifyClusterViolationsInListing(clusterName, violationCounter, violatedPolicies)
-      //cy.verifyClusterViolationsInListing(clusterName)
+      if (Cypress.env('STANDALONE_TESTSUITE_EXECUTION') !== 'FALSE') {
+        cy.verifyClusterViolationsInListing(clusterName, violationCounter, violatedPolicies)
+      } else {
+        cy.verifyClusterViolationsInListing(clusterName)
+      }
     })
 
   }
@@ -181,16 +197,25 @@ export const test_genericPolicyGovernance = (confFilePolicy, confFileViolationsI
         // BEWARE: The check would only work if there were no other policies present on the cluster
         // if this is not the case, avoid passing violationCounter and violatedPolicies to
         // waitForClusterViolationsStatus() and verifyClusterViolationsInListing() functions below
+        // Currently this is controlled using STANDALONE_TESTSUITE_EXECUTION variable
         it('Wait for cluster violation status to become available', () => {
           // switch to the Clusters tab
           cy.get('#grc-cluster-view').click()
-            .waitForClusterViolationsStatus(clusterName, violationCounter)
-           //.waitForClusterViolationsStatus(clusterName)
+            .then(() => {
+              if (Cypress.env('STANDALONE_TESTSUITE_EXECUTION') !== 'FALSE') {
+                cy.waitForClusterViolationsStatus(clusterName, violationCounter)
+              } else {
+                cy.waitForClusterViolationsStatus(clusterName)
+              }
+            })
         })
 
         it(`Check cluster ${clusterName} violations`, () => {
-          cy.verifyClusterViolationsInListing(clusterName, violationCounter, violatedPolicies)
-          //cy.verifyClusterViolationsInListing(clusterName)
+          if (Cypress.env('STANDALONE_TESTSUITE_EXECUTION') !== 'FALSE') {
+            cy.verifyClusterViolationsInListing(clusterName, violationCounter, violatedPolicies)
+          } else {
+            cy.verifyClusterViolationsInListing(clusterName)
+          }
         })
 
       }

--- a/tests/cypress/common/views.js
+++ b/tests/cypress/common/views.js
@@ -1309,7 +1309,7 @@ export const action_verifyClusterViolationsInListing = (clusterName, violationsC
       if (violationsCounter) {
         cy.wrap(violations.textContent).should('match', new RegExp('^'+violationsCounter+'$'))
       } else {
-        cy.wrap(violations.textContent).should('match', new RegExp('^[0-9]+\/[0-9]+$'))
+        cy.wrap(violations.textContent).should('match', /^[0-9]+\/[0-9]+$/)
       }
       // check violated policies
       // in fact there is no sense checking it precisely since policy listing woudl be truncated in the UI

--- a/tests/cypress/common/views.js
+++ b/tests/cypress/common/views.js
@@ -1308,6 +1308,8 @@ export const action_verifyClusterViolationsInListing = (clusterName, violationsC
       // check the cluster violations counter value
       if (violationsCounter) {
         cy.wrap(violations.textContent).should('match', new RegExp('^'+violationsCounter+'$'))
+      } else {
+        cy.wrap(violations.textContent).should('match', new RegExp('^[0-9]+\/[0-9]+$'))
       }
       // check violated policies
       // in fact there is no sense checking it precisely since policy listing woudl be truncated in the UI

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -292,7 +292,7 @@ Cypress.Commands.add('verifyClusterViolationsInListing', (clusterName, violation
 })
 
 // must be run on /multicloud/policies/all
-Cypress.Commands.add('verifyCardsOnPolicyListingPage', (cardName, cardValuesDict) => {
+Cypress.Commands.add('verifyCardsOnPolicyListingPage', (cardName, cardValuesDict, skipNumCardsCheck=false) => {
   const numCards = Object.keys(cardValuesDict).length
   cy.url().should('match', /\/multicloud\/policies\/all[?]?/)
   // switch to the required card
@@ -303,12 +303,18 @@ Cypress.Commands.add('verifyCardsOnPolicyListingPage', (cardName, cardValuesDict
   // check the summary header and counter
   cy.get('#summary-toggle').within(() => {
     cy.get('.header-title').contains('Summary')
-    cy.get('.grc-cards-count').contains(new RegExp('^'+numCards+'$'))
+    if (skipNumCardsCheck) {  // loosened check for unknown card number
+      cy.get('.grc-cards-count').contains(/^[0-9]+$/)
+    } else {
+      cy.get('.grc-cards-count').contains(new RegExp('^'+numCards+'$'))
+    }
   })
   // check number of cards displayed
-  cy.get('dd.grc-cards-container').within(() => {
-    cy.get('.card-container').should('have.length', numCards)
-  })
+  if (!skipNumCardsCheck) {
+    cy.get('dd.grc-cards-container').within(() => {
+      cy.get('.card-container').should('have.length', numCards)
+    })
+  }
   // verify all cards
   for (const [name, violations] of Object.entries(cardValuesDict)) {
     // find card by name

--- a/tests/cypress/tests/all_policies_summary_table.spec.js
+++ b/tests/cypress/tests/all_policies_summary_table.spec.js
@@ -59,13 +59,14 @@ describe('RHACM4K-2343 - [P1][Sev1][policy-grc] All policies page: Verify summar
         'NIST-CSF': [/[0-9]+\/[0-9]+/, /[0-9]+\/[0-9]+/],
         'FISMA': [/[0-9]+\/[0-9]+/, /[0-9]+\/[0-9]+/]
       }
+      cy.verifyCardsOnPolicyListingPage('Standards', violationCounters, true)
     } else {
       violationCounters = {
         'NIST-CSF': [`${clusterCount}/${clusterCount}`, `${2*clusterCount}/${2*clusterCount}`],
         'FISMA': [`${clusterCount}/${clusterCount}`, `${clusterCount}/${clusterCount}`]
       }
+      cy.verifyCardsOnPolicyListingPage('Standards', violationCounters)
     }
-    cy.verifyCardsOnPolicyListingPage('Standards', violationCounters)
   })
 
   it('Verify the content of Categories card', () => {
@@ -76,14 +77,15 @@ describe('RHACM4K-2343 - [P1][Sev1][policy-grc] All policies page: Verify summar
         'PR.DS Data Security': [/[0-9]+\/[0-9]+/, /[0-9]+\/[0-9]+/],
         'PR.IP Information Protec...rocesses and Procedures': [/[0-9]+\/[0-9]+/, /[0-9]+\/[0-9]+/],
       }
+      cy.verifyCardsOnPolicyListingPage('Categories', violatonCounters, true)
     } else {
       violatonCounters = {
         'PR.AC Identity Management and Access Control': [`${clusterCount}/${clusterCount}`, `${clusterCount}/${clusterCount}`],
         'PR.DS Data Security': [`${clusterCount}/${clusterCount}`, `${clusterCount}/${clusterCount}`],
         'PR.IP Information Protec...rocesses and Procedures': [`${clusterCount}/${clusterCount}`, `${clusterCount}/${clusterCount}`],
       }
+      cy.verifyCardsOnPolicyListingPage('Categories', violatonCounters)
     }
-    cy.verifyCardsOnPolicyListingPage('Categories', violatonCounters)
   })
 
   // delete created policies at the end

--- a/tests/cypress/tests/all_policies_summary_table.spec.js
+++ b/tests/cypress/tests/all_policies_summary_table.spec.js
@@ -1,6 +1,11 @@
 /* Copyright (c) 2020 Red Hat, Inc. */
 /* Copyright Contributors to the Open Cluster Management project */
 
+// BEWARE: The execution if this test is altered by an environment variable
+// STANDALONE_TESTSUITE_EXECUTION (resp. CYPRESS_STANDALONE_TESTSUITE_EXECUTION)
+// when set to 'FALSE', some checks are loosened due to possible conflicts with
+// other tests running in the environment
+
 /// <reference types="cypress" />
 import { getConfigObject } from '../config'
 
@@ -12,11 +17,14 @@ describe('RHACM4K-2343 - [P1][Sev1][policy-grc] All policies page: Verify summar
   // policy-config is used for policy creation and validation
   const confPolicies = getConfigObject('all_policies_summary_table/policy-config.yaml', 'yaml', substitutionRules)
 
-  // first check there are no policies, otherwise numbers won't match
-  it('Verify there are no policies present', () => {
-    cy.get('div.no-resource')  // there should be no-resource element
-      .get('.grc-view-by-policies-table').should('not.exist')  // there should not be policy table
-  })
+
+  if (Cypress.env('STANDALONE_TESTSUITE_EXECUTION') !== 'FALSE') {
+    // first check there are no policies, otherwise numbers won't match
+    it('Verify there are no policies present', () => {
+     cy.get('div.no-resource')  // there should be no-resource element
+        .get('.grc-view-by-policies-table').should('not.exist')  // there should not be policy table
+    })
+  }
 
   // create all three policies
   for (const policyName in confPolicies) {
@@ -44,18 +52,36 @@ describe('RHACM4K-2343 - [P1][Sev1][policy-grc] All policies page: Verify summar
 
   // verify the actual card content
   it('Verify the content of Standards card', () => {
-    const violationCounters = {
-      'NIST-CSF': [`${clusterCount}/${clusterCount}`, `${2*clusterCount}/${2*clusterCount}`],
-      'FISMA': [`${clusterCount}/${clusterCount}`, `${clusterCount}/${clusterCount}`]
+    let violationCounters
+    // if not running testsuite standalone, loose checks
+    if (Cypress.env('STANDALONE_TESTSUITE_EXECUTION') === 'FALSE') {
+      violationCounters = {
+        'NIST-CSF': [/[0-9]+\/[0-9]+/, /[0-9]+\/[0-9]+/],
+        'FISMA': [/[0-9]+\/[0-9]+/, /[0-9]+\/[0-9]+/]
+      }
+    } else {
+      violationCounters = {
+        'NIST-CSF': [`${clusterCount}/${clusterCount}`, `${2*clusterCount}/${2*clusterCount}`],
+        'FISMA': [`${clusterCount}/${clusterCount}`, `${clusterCount}/${clusterCount}`]
+      }
     }
     cy.verifyCardsOnPolicyListingPage('Standards', violationCounters)
   })
 
   it('Verify the content of Categories card', () => {
-    const violatonCounters = {
-      'PR.AC Identity Management and Access Control': [`${clusterCount}/${clusterCount}`, `${clusterCount}/${clusterCount}`],
-      'PR.DS Data Security': [`${clusterCount}/${clusterCount}`, `${clusterCount}/${clusterCount}`],
-      'PR.IP Information Protec...rocesses and Procedures': [`${clusterCount}/${clusterCount}`, `${clusterCount}/${clusterCount}`],
+    let violatonCounters
+    if (Cypress.env('STANDALONE_TESTSUITE_EXECUTION') === 'FALSE') {
+      violatonCounters = {
+        'PR.AC Identity Management and Access Control': [/[0-9]+\/[0-9]+/, /[0-9]+\/[0-9]+/],
+        'PR.DS Data Security': [/[0-9]+\/[0-9]+/, /[0-9]+\/[0-9]+/],
+        'PR.IP Information Protec...rocesses and Procedures': [/[0-9]+\/[0-9]+/, /[0-9]+\/[0-9]+/],
+      }
+    } else {
+      violatonCounters = {
+        'PR.AC Identity Management and Access Control': [`${clusterCount}/${clusterCount}`, `${clusterCount}/${clusterCount}`],
+        'PR.DS Data Security': [`${clusterCount}/${clusterCount}`, `${clusterCount}/${clusterCount}`],
+        'PR.IP Information Protec...rocesses and Procedures': [`${clusterCount}/${clusterCount}`, `${clusterCount}/${clusterCount}`],
+      }
     }
     cy.verifyCardsOnPolicyListingPage('Categories', violatonCounters)
   })


### PR DESCRIPTION
There are tests that expect no policy being present on a cluster
before test starts in order to be able to do precide content checks.
When testsuite is run in parallel with other tests, this condition
is not met.
This commit introduces loosening of such checks which is enabled
by setting the environment variable
STANDALONE_TESTSUITE_EXECUTION
(resp. CYPRESS_STANDALONE_TESTSUITE_EXECUTION)
to 'FALSE'.