### PR TITLE
Update e2e Dockerfile

### DIFF
--- a/Dockerfile.e2etest
+++ b/Dockerfile.e2etest
@@ -30,6 +30,7 @@ RUN npm install \
     cypress-terminal-report \
     cypress-wait-until \
     cypress-fail-fast \
+    cypress-tags \
     @cypress/code-coverage \
     mocha \
     mocha-junit-reporter \

--- a/build/run-docker-tests.sh
+++ b/build/run-docker-tests.sh
@@ -54,6 +54,11 @@ export PAUSE=${PAUSE:-60}
 echo sleep $PAUSE seconds cypress ...
 sleep $PAUSE
 export CI=true # force cypress to output color
+# Check for standalone test suite flag to loosen tests if there are other policies present from concurrent tests
+if [ ${STANDALONE_TESTSUITE_EXECUTION} == "false" ]; then
+  export CYPRESS_STANDALONE_TESTSUITE_EXECUTION="FALSE"
+fi
+# Check for fail_fast flag to stop tests on failure
 if [ $FAIL_FAST == "true" ]; then
   echo "Running in fail fast mode"
   npm run test:cypress-headless

--- a/build/run-docker-tests.sh
+++ b/build/run-docker-tests.sh
@@ -27,7 +27,6 @@ export SKIP_LOG_DELETE=${SKIP_LOG_DELETE:-true}
 export DISABLE_CANARY_TEST=${DISABLE_CANARY_TEST:-false}
 export FAIL_FAST=${FAIL_FAST:-false}
 
-
 # show all envs
 printenv
 # test oauth server and see if idp has been setup
@@ -55,7 +54,7 @@ echo sleep $PAUSE seconds cypress ...
 sleep $PAUSE
 export CI=true # force cypress to output color
 # Check for standalone test suite flag to loosen tests if there are other policies present from concurrent tests
-if [ ${STANDALONE_TESTSUITE_EXECUTION} == "false" ]; then
+if [ "${STANDALONE_TESTSUITE_EXECUTION}" == "false" ]; then
   export CYPRESS_STANDALONE_TESTSUITE_EXECUTION="FALSE"
 fi
 # Check for fail_fast flag to stop tests on failure

--- a/package-lock.json
+++ b/package-lock.json
@@ -22505,12 +22505,6 @@
         "is-typedarray": "^1.0.0"
       }
     },
-    "typescript": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.3.tgz",
-      "integrity": "sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==",
-      "dev": true
-    },
     "uglify-js": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22505,6 +22505,12 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "typescript": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.3.tgz",
+      "integrity": "sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==",
+      "dev": true
+    },
     "uglify-js": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.0.tgz",

--- a/package.json
+++ b/package.json
@@ -173,7 +173,8 @@
     "properties-parser": "^0.3.1",
     "redux-mock-store": "^1.5.4",
     "resolve-url-loader": "^3.1.2",
-    "svg-sprite-loader": "^5.0.0"
+    "svg-sprite-loader": "^5.0.0",
+    "typescript": "^4.2.3"
   },
   "nyc": {
     "report-dir": "./test-output/cypress/coverage",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "cross-env": "^7.0.2",
     "css-loader": "^3.6.0",
     "csurf": "^1.11.0",
-    "cypress-tags": "0.0.20",
     "deep-diff": "^1.0.2",
     "del-cli": "^3.0.1",
     "eslint": "^7.21.0",
@@ -127,7 +126,6 @@
     "source-map-loader": "^1.1.2",
     "style-loader": "^1.3.0",
     "terser-webpack-plugin": "^4.2.3",
-    "typescript": "^4.2.3",
     "webpack": "^4.46.0",
     "webpack-cli": "^4.4.0"
   },
@@ -142,6 +140,7 @@
     "cypress": "^6.6.0",
     "cypress-fail-fast": "^2.2.0",
     "cypress-multi-reporters": "^1.4.0",
+    "cypress-tags": "^0.0.20",
     "cypress-terminal-report": "^2.4.0",
     "cypress-wait-until": "^1.7.1",
     "enzyme": "^3.11.0",


### PR DESCRIPTION
- Update to move `cypress-tags` to dev and add to the test image
- Add `STANDALONE_TESTSUITE_EXECUTION` to test script
- ~I also removed the `typescript` dependency. I'm not sure how it got in there...~ Update: `cypress-tags` relies on Typescript. Oops. 🙂 