### PR TITLE
Add typescript to test image

### DIFF
--- a/Dockerfile.e2etest
+++ b/Dockerfile.e2etest
@@ -31,6 +31,7 @@ RUN npm install \
     cypress-wait-until \
     cypress-fail-fast \
     cypress-tags \
+    typescript \
     @cypress/code-coverage \
     mocha \
     mocha-junit-reporter \


### PR DESCRIPTION
`cypress-tags` depends on `typescript`