### PR TITLE
Set YAML parse error object directly

### DIFF
--- a/src-web/components/common/TemplateEditor/components/YamlParser.js
+++ b/src-web/components/common/TemplateEditor/components/YamlParser.js
@@ -799,8 +799,8 @@ class YamlParser {
           key = new YamlInline().parseScalar(values.key)
         } catch (e) {
           if (e instanceof YamlParseException) {
-            e.setParsedLine(this.getRealCurrentLineNb() + 1)
-            e.setSnippet(this.currentLine)
+            e.parsedLine = this.getRealCurrentLineNb() + 1
+            e.snippet = this.currentLine
           }
           throw e
         }
@@ -900,8 +900,8 @@ class YamlParser {
             value = new YamlInline().parse(this.lines[0])
           } catch (e) {
             if (e instanceof YamlParseException) {
-              e.setParsedLine(this.getRealCurrentLineNb() + 1)
-              e.setSnippet(this.currentLine)
+              e.parsedLine = this.getRealCurrentLineNb() + 1
+              e.snippet = this.currentLine
             }
             throw e
           }
@@ -1141,8 +1141,8 @@ class YamlParser {
       return new YamlInline().parse(value)
     } catch (e) {
       if (e instanceof YamlParseException) {
-        e.setParsedLine(this.getRealCurrentLineNb() + 1)
-        e.setSnippet(this.currentLine)
+        e.parsedLine = this.getRealCurrentLineNb() + 1
+        e.snippet = this.currentLine
       }
       throw e
     }


### PR DESCRIPTION
It appears `setParsedLine` and `setSnippet` no longer work to set these values, but setting the error object directly seems to work.

**original:**
![image](https://user-images.githubusercontent.com/19750917/111525110-9b172800-8733-11eb-81fe-0f2fc72bb6da.png)

**updated:**
![image](https://user-images.githubusercontent.com/19750917/111525080-905c9300-8733-11eb-844f-8b5e860bc4bf.png)
