### PR TITLE
removed cypress-tags; added custom test tagging mechanism

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6624,7 +6624,7 @@
         "p-map": "^4.0.0",
         "promise-inflight": "^1.0.1",
         "rimraf": "^3.0.2",
-        "ssri": "^8.0.1",
+        "ssri": "^8.0.0",
         "tar": "^6.0.2",
         "unique-filename": "^1.1.1"
       }
@@ -8431,17 +8431,6 @@
       "requires": {
         "debug": "^4.1.1",
         "lodash": "^4.17.15"
-      }
-    },
-    "cypress-tags": {
-      "version": "0.0.20",
-      "resolved": "https://registry.npmjs.org/cypress-tags/-/cypress-tags-0.0.20.tgz",
-      "integrity": "sha512-svGX0EmUopPQyGJJFjnVmB9O9r61Rz3ugPhPeY1xMYWwLGWEkhNCQEjdlgScOjh1mJZQJhBKUa8Scs7C184HVA==",
-      "dev": true,
-      "requires": {
-        "@cypress/browserify-preprocessor": "^3.0.1",
-        "cypress": "^6.5.0",
-        "through": "^2.3.8"
       }
     },
     "cypress-terminal-report": {
@@ -21661,8 +21650,8 @@
       }
     },
     "ssri": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.0.tgz",
       "integrity": "sha512-aq/pz989nxVYwn16Tsbj1TqFpD5LLrQxHf5zaHuieFV+R0Bbr4y8qUsOA45hXT/N4/9UNXTarBjnjVmjSOVaAA==",
       "requires": {
         "minipass": "^3.1.1"
@@ -23083,12 +23072,6 @@
         "is-typedarray": "^1.0.0"
       }
     },
-    "typescript": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.3.tgz",
-      "integrity": "sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==",
-      "dev": true
-    },
     "uglify-js": {
       "version": "3.13.0",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.13.0.tgz",
@@ -23856,7 +23839,7 @@
             "move-concurrently": "^1.0.1",
             "promise-inflight": "^1.0.1",
             "rimraf": "^2.6.3",
-            "ssri": "^8.0.1",
+            "ssri": "^6.0.1",
             "unique-filename": "^1.1.1",
             "y18n": "^4.0.0"
           }
@@ -23984,8 +23967,8 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
         },
         "ssri": {
-          "version": "8.0.1",
-          "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
           "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
           "requires": {
             "figgy-pudding": "^3.5.1"

--- a/package.json
+++ b/package.json
@@ -140,7 +140,6 @@
     "cypress": "^6.8.0",
     "cypress-fail-fast": "^2.2.0",
     "cypress-multi-reporters": "^1.4.0",
-    "cypress-tags": "^0.0.20",
     "cypress-terminal-report": "^2.4.0",
     "cypress-wait-until": "^1.7.1",
     "enzyme": "^3.11.0",
@@ -173,8 +172,7 @@
     "properties-parser": "^0.3.1",
     "redux-mock-store": "^1.5.4",
     "resolve-url-loader": "^3.1.2",
-    "svg-sprite-loader": "^5.2.1",
-    "typescript": "^4.2.3"
+    "svg-sprite-loader": "^5.2.1"
   },
   "nyc": {
     "report-dir": "./test-output/cypress/coverage",

--- a/tests/cypress/plugins/index.js
+++ b/tests/cypress/plugins/index.js
@@ -11,13 +11,11 @@ const glob = require('glob')
 const path = require('path')
 const getConfig = require('../config').getConfig
 const configFiles = glob.sync(path.join(__dirname, '../config/**/*'), {nodir:true, ignore:[path.join(__dirname, '../config/index.js')]})
-const tagify = require('cypress-tags')
 
 module.exports = (on, config) => {
   require('@cypress/code-coverage/task')(on, config)
   // `on` is used to hook into various events Cypress emits
   // `config` is the resolved Cypress config
-  on('file:preprocessor', tagify(config))
 
   for (const singleConfig of configFiles) {
     // get base name, replace . and - with _ and convert to uppercase

--- a/tests/cypress/start_cypress_tests.sh
+++ b/tests/cypress/start_cypress_tests.sh
@@ -91,6 +91,9 @@ else
   echo "Running cypess under browser headless model."
 fi
 
+# CYPRESS_TAGS_EXCLUDE is just a test tag filtering demo. It should not be applied by default!!!
+export CYPRESS_TAGS_EXCLUDE="@extended"
+
 if [ "$NODE_ENV" == "dev" ]; then
   npx cypress run --browser $BROWSER $HEADLESS --spec "./tests/cypress/tests/*.spec.js" --reporter cypress-multi-reporters  
 elif [ "$NODE_ENV" == "debug" ]; then

--- a/tests/cypress/start_cypress_tests.sh
+++ b/tests/cypress/start_cypress_tests.sh
@@ -71,6 +71,8 @@ echo -e "\tCYPRESS_MANAGED_CLUSTER_NAME       : $CYPRESS_MANAGED_CLUSTER_NAME"
 echo -e "\tCYPRESS_FAIL_FAST_PLUGIN       : $CYPRESS_FAIL_FAST_PLUGIN"
 echo -e "\tCYPRESS_STANDALONE_TESTSUITE_EXECUTION: $CYPRESS_STANDALONE_TESTSUITE_EXECUTION"
 echo -e "\tCYPRESS_coverage       : $CYPRESS_coverage"
+echo -e "\tCYPRESS_TAGS_INCLUDE          : $CYPRESS_TAGS_INCLUDE"
+echo -e "\tCYPRESS_TAGS_EXCLUDE          : $CYPRESS_TAGS_EXCLUDE"
 
 echo -e "\nLogging into Kube API server\n"
 oc login --server=${CYPRESS_OPTIONS_HUB_CLUSTER_URL} -u $CYPRESS_OPTIONS_HUB_USER -p $CYPRESS_OPTIONS_HUB_PASSWORD --insecure-skip-tls-verify
@@ -90,9 +92,6 @@ if [[ "$LIVE_MODE" == true ]]; then
 else
   echo "Running cypess under browser headless model."
 fi
-
-# CYPRESS_TAGS_EXCLUDE is just a test tag filtering demo. It should not be applied by default!!!
-export CYPRESS_TAGS_EXCLUDE="@extended"
 
 if [ "$NODE_ENV" == "dev" ]; then
   npx cypress run --browser $BROWSER $HEADLESS --spec "./tests/cypress/tests/*.spec.js" --reporter cypress-multi-reporters  

--- a/tests/cypress/support/tagging.js
+++ b/tests/cypress/support/tagging.js
@@ -1,0 +1,58 @@
+/* Copyright (c) 2021 Red Hat, Inc. */
+/* Copyright Contributors to the Open Cluster Management project */
+
+// evaluates tags against filters stored in environment variables
+// CYPRESS_TAGS_INCLUDE (evaluated first)
+// CYPRESS_TAGS_EXCLUDE (excluding from the set build previously)
+// filter is a regular expression for alphabetically sorted string of space separated tags
+const evaluateFilter = (tags) => {
+  let passed = true
+  const includeRegExp = Cypress.env('TAGS_INCLUDE')
+  console.log(`evaluating tags: ${tags}`)
+  console.log(`include regexp: ${includeRegExp}`)
+  const excludeRegExp = Cypress.env('TAGS_EXCLUDE')
+  console.log(`exclude regexp: ${excludeRegExp}`)
+  // first include tags
+  if (includeRegExp) {
+    const regexp = new RegExp(includeRegExp)
+    passed = regexp.test(tags)
+  }
+  if (passed && excludeRegExp) {
+    const regexp = new RegExp(excludeRegExp)
+    passed = ! regexp.test(tags)
+  }
+  console.log(`Test tag match evaluation result: ${passed}`)
+  return passed
+}
+
+// decide whether a specific test function should be executed or not
+// tags have format '@name', stored as a space separated string, prefix of a test title
+const filterTestFuntionCall = (testFunction, title, callback) => {
+  const tags = title.match(/(@[a-z0-9_]+ *)*/)[0]
+  const inheritedTags = window.cypressTestTags ? window.cypressTestTags : ''
+  console.log(`Parsed test tags: ${tags}`)
+  console.log(`Inherited test tags: ${inheritedTags}`)
+  const allTagsSet = new Set(`${tags} ${inheritedTags}`.split(' '))  // eliminate duplicates
+  const allTagsArray = Array.from(allTagsSet)  // convert back to array
+  allTagsArray.sort()  // sort it
+  const allTags = allTagsArray.join(' ')  // convert back to string
+  // evaluate if test match required tag filter
+  if (evaluateFilter(allTags)) {
+    window.cypressTestTags = allTags  // propagate new set of tags
+    testFunction(title, callback)  // run the wrapped test function
+    window.cypressTestTags = inheritedTags  // restore old set of tags
+  } else {  // do nothing
+    console.log(`Test was skipped: ${title}`)
+  }
+}
+
+// wrapper for describe() supporting tags in title
+// e.g. describeT('@fast @stable Login to RHACM as user kubeadmin', () => { ...
+export const describeT = (title, callback) => {
+  filterTestFuntionCall(describe, title, callback)
+}
+
+// wrapper for it() supporting tags in title
+export const itT = (title, callback) => {
+  filterTestFuntionCall(it, title, callback)
+}

--- a/tests/cypress/tests/CertPolicy_governance.spec.js
+++ b/tests/cypress/tests/CertPolicy_governance.spec.js
@@ -2,6 +2,7 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
 /// <reference types="cypress" />
+import { describeT } from '../support/tagging'
 import { getDefaultSubstitutionRules, verifyPolicyInPolicyStatus, verifyPolicyByYAML } from '../common/views'
 import { test_applyPolicyYAML } from  '../common/tests'
 import { getUniqueResourceName } from '../scripts/utils'
@@ -16,7 +17,7 @@ if (Cypress.env('MANAGED_CLUSTER_NAME') !== undefined) {
 }
 
 
-describe('Setup - create a certificate expiring soon', () => {
+describeT('Setup - create a certificate expiring soon', () => {
   const substitutionRules = getDefaultSubstitutionRules({
     clusterselector:`- {key: name, operator: In, values: ["${clusterList[0]}"]}`,
     compliancetype: 'musthave'
@@ -34,7 +35,7 @@ describe('Setup - create a certificate expiring soon', () => {
 })
 
 
-describe('RHACM4K-2294 - GRC UI: [P1][Sev1][policy-grc] - CertificatePolicy governance', () => {
+describeT('RHACM4K-2294 - GRC UI: [P1][Sev1][policy-grc] - CertificatePolicy governance', () => {
   const certificatePolicyName = 'policy-certificatepolicy'
   const uCertificatePolicyName = getUniqueResourceName(certificatePolicyName)
   const substitutionRules = getDefaultSubstitutionRules({policyname:uCertificatePolicyName, clusterselector:`- {key: name, operator: In, values: ["${clusterList[0]}"]}`})
@@ -118,7 +119,7 @@ describe('RHACM4K-2294 - GRC UI: [P1][Sev1][policy-grc] - CertificatePolicy gove
 })
 
 
-describe('RHACM4K_1205 - GRC UI: [P1][Sev1][policy-grc] - CertificatePolicy governance', () => {
+describeT('RHACM4K_1205 - GRC UI: [P1][Sev1][policy-grc] - CertificatePolicy governance', () => {
   const certificatePolicyName = 'policy-certificatepolicy-rhacm4k-1205'
   const uCertificatePolicyName = getUniqueResourceName(certificatePolicyName)
   const substitutionRules = getDefaultSubstitutionRules({policyname:uCertificatePolicyName, clusterselector:`- {key: name, operator: In, values: ["${clusterList[0]}"]}`})
@@ -202,7 +203,7 @@ describe('RHACM4K_1205 - GRC UI: [P1][Sev1][policy-grc] - CertificatePolicy gove
 })
 
 
-describe('Cleanup - delete a certificate and an issuer', () => {
+describeT('Cleanup - delete a certificate and an issuer', () => {
   const substitutionRulesCleanup = getDefaultSubstitutionRules({
     clusterselector:`- {key: name, operator: In, values: ["${clusterList[0]}"]}`,
     compliancetype: 'mustnothave'

--- a/tests/cypress/tests/DuplicatePolicyInDiffNS.spec.js
+++ b/tests/cypress/tests/DuplicatePolicyInDiffNS.spec.js
@@ -1,10 +1,14 @@
 /* Copyright (c) 2020 Red Hat, Inc. */
 /// <reference types="cypress" />
+
+import { describeT } from '../support/tagging'
 import { getConfigObject } from '../config'
 import { getDefaultSubstitutionRules } from '../common/views'
+
 const substitutionRules = getDefaultSubstitutionRules()
 var policyNames = []
-describe('RHACM4K-2342 - GRC UI: [P1][Sev1][policy-grc] Verify create policy with different NS', () => {
+
+describeT('RHACM4K-2342 - GRC UI: [P1][Sev1][policy-grc] Verify create policy with different NS', () => {
   it('Create Namespace policy to create template ns as duplicatetest', () => {
     const confFilePolicy = 'duplicatePolicyInDiffNS/create_ns_template.yaml'
     const rawPolicyYAML = getConfigObject(confFilePolicy, 'raw', substitutionRules)

--- a/tests/cypress/tests/IamPolicy_governance.spec.js
+++ b/tests/cypress/tests/IamPolicy_governance.spec.js
@@ -2,16 +2,17 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
 /// <reference types="cypress" />
+import { describeT } from '../support/tagging'
 import { test_genericPolicyGovernance, test_applyPolicyYAML } from '../common/tests'
 
-describe('GRC UI: [P1][Sev1][policy-grc] IamPolicy governance - setup', () => {
+describeT('GRC UI: [P1][Sev1][policy-grc] IamPolicy governance - setup', () => {
   test_applyPolicyYAML('IamPolicy_governance/policy-clusterrolebinding-setup_raw.yaml')
 })
 
-describe('RHACM4K-1719 - GRC UI: [P1][Sev1][policy-grc] IamPolicy governance', () => {
+describeT('RHACM4K-1719 - GRC UI: [P1][Sev1][policy-grc] IamPolicy governance', () => {
   test_genericPolicyGovernance('IamPolicy_governance/policy-config.yaml', 'IamPolicy_governance/violations-inform.yaml', 'IamPolicy_governance/violations-inform.yaml')
 })
 
-describe('GRC UI: [P1][Sev1][policy-grc] IamPolicy governance - cleanup', () => {
+describeT('GRC UI: [P1][Sev1][policy-grc] IamPolicy governance - cleanup', () => {
   test_applyPolicyYAML('IamPolicy_governance/policy-clusterrolebinding-cleanup_raw.yaml')
 })

--- a/tests/cypress/tests/ImageManifest_governance.spec.js
+++ b/tests/cypress/tests/ImageManifest_governance.spec.js
@@ -2,16 +2,17 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
 /// <reference types="cypress" />
+import { describeT } from '../support/tagging'
 import { test_genericPolicyGovernance, test_applyPolicyYAML } from '../common/tests.js'
 import { getClusterListByVendor } from '../config'
 
 const getList = getClusterListByVendor('OpenShift')
 
 if (getList.length>0) {
-  describe('RHACM4K-1727 - GRC UI: [P1][Sev1][policy-grc] ImageManifest policy governance', () => {
+  describeT('RHACM4K-1727 - GRC UI: [P1][Sev1][policy-grc] ImageManifest policy governance', () => {
   test_genericPolicyGovernance('ImageManifest_governance/policy-config.yaml', 'ImageManifest_governance/violations-inform.yaml', 'ImageManifest_governance/violations-enforce.yaml', 'clusters.yaml', getList)
 })
-  describe('GRC UI: [P1][Sev1][policy-grc] ImageManifest governance - cleanup', () => {
+  describeT('GRC UI: [P1][Sev1][policy-grc] ImageManifest governance - cleanup', () => {
     test_applyPolicyYAML('ImageManifest_governance/ImageManifest_specification_cleanup_policy_raw.yaml')
   })
 }

--- a/tests/cypress/tests/InvalidYaml_governance.spec.js
+++ b/tests/cypress/tests/InvalidYaml_governance.spec.js
@@ -2,12 +2,13 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
 /// <reference types="cypress" />
+import { describeT } from '../support/tagging'
 import { getConfigObject } from '../config'
 import { getDefaultSubstitutionRules } from '../common/views'
 const invalidYamlErrorMessages = getConfigObject('InvalidYamlTests/invalidYamlErrors.yaml', 'yaml')
 
 
-describe('RHACM4K-247 - GRC UI: [P1][Sev1][policy-grc] Create policy with invalid yaml', () => {
+describeT('RHACM4K-247 - GRC UI: [P1][Sev1][policy-grc] Create policy with invalid yaml', () => {
   it('Create policy should fail with invalid policy name in yaml', () => {
     const confFilePolicy = 'InvalidYamlTests/InvalidPolicyName.yaml'
     const rawPolicyYAML = getConfigObject(confFilePolicy, 'raw', getDefaultSubstitutionRules())

--- a/tests/cypress/tests/LimitRange_governance.spec.js
+++ b/tests/cypress/tests/LimitRange_governance.spec.js
@@ -2,16 +2,17 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
 /// <reference types="cypress" />
+import { describeT } from '../support/tagging'
 import { test_genericPolicyGovernance, test_applyPolicyYAML } from '../common/tests'
 
-describe(['extended'], 'GRC UI: [P1][Sev1][policy-grc] LimitRange policy governance - setup', () => {
+describeT('@extended GRC UI: [P1][Sev1][policy-grc] LimitRange policy governance - setup', () => {
     test_applyPolicyYAML('LimitRange_governance/LimitRange_specification_setup_policy_raw.yaml')
 })
 
-describe(['extended'], 'RHACM4K-1726 - GRC UI: [P1][Sev1][policy-grc] LimitRange policy governance', () => {
+describeT('@extended RHACM4K-1726 - GRC UI: [P1][Sev1][policy-grc] LimitRange policy governance', () => {
     test_genericPolicyGovernance('LimitRange_governance/policy-config.yaml', 'LimitRange_governance/violations-inform.yaml', 'LimitRange_governance/violations-enforce.yaml')
 })
 //setup & clean up yaml files are identical
-describe(['extended'], 'GRC UI: [P1][Sev1][policy-grc] LimitRange policy governance - clean up', () => {
+describeT('@extended GRC UI: [P1][Sev1][policy-grc] LimitRange policy governance - clean up', () => {
     test_applyPolicyYAML('LimitRange_governance/LimitRange_specification_setup_policy_raw.yaml')
 })

--- a/tests/cypress/tests/Namespace_governance.spec.js
+++ b/tests/cypress/tests/Namespace_governance.spec.js
@@ -2,14 +2,15 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
 /// <reference types="cypress" />
+import { describeT } from '../support/tagging'
 import { test_genericPolicyGovernance, test_applyPolicyYAML } from '../common/tests'
 
-describe(['extended'], 'GRC UI: [P1][Sev1][policy-grc] Namespace policy governance - setup', () => {
+describeT('@extended GRC UI: [P1][Sev1][policy-grc] Namespace policy governance - setup', () => {
     test_applyPolicyYAML('Namespace_governance/Namespace_specification_setup_policy_raw.yaml')
 })
-describe(['extended'], 'RHACM4K-1725 - GRC UI: [P1][Sev1][policy-grc] Namespace policy governance', () => {
+describeT('@extended RHACM4K-1725 - GRC UI: [P1][Sev1][policy-grc] Namespace policy governance', () => {
     test_genericPolicyGovernance('Namespace_governance/policy-config.yaml', 'Namespace_governance/violations-inform.yaml', 'Namespace_governance/violations-enforce.yaml')
 })
-describe(['extended'], 'GRC UI: [P1][Sev1][policy-grc] Namespace policy governance - clean up', () => {
+describeT('@extended GRC UI: [P1][Sev1][policy-grc] Namespace policy governance - clean up', () => {
     test_applyPolicyYAML('Namespace_governance/Namespace_specification_cleanup_policy_raw.yaml')
 })

--- a/tests/cypress/tests/PodSecurityPolicy_governance.spec.js
+++ b/tests/cypress/tests/PodSecurityPolicy_governance.spec.js
@@ -2,12 +2,13 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
 /// <reference types="cypress" />
+import { describeT } from '../support/tagging'
 import { test_genericPolicyGovernance, test_applyPolicyYAML } from '../common/tests'
 
-describe(['extended'], 'RHACM4K-1720 - GRC UI: [P1][Sev1][policy-grc] PodSecurityPolicy governance', () => {
+describeT('@extended RHACM4K-1720 - GRC UI: [P1][Sev1][policy-grc] PodSecurityPolicy governance', () => {
   test_genericPolicyGovernance('PodSecurityPolicy_governance/policy-config.yaml', 'PodSecurityPolicy_governance/violations-inform.yaml', 'PodSecurityPolicy_governance/violations-enforce.yaml')
 })
 
-describe(['extended'], 'GRC UI: [P1][Sev1][policy-grc] PodSecurityPolicy governance - clean up', () => {
+describeT('@extended GRC UI: [P1][Sev1][policy-grc] PodSecurityPolicy governance - clean up', () => {
   test_applyPolicyYAML('PodSecurityPolicy_governance/PodSecurityPolicy_cleanup_policy_raw.yaml')
 })

--- a/tests/cypress/tests/Pod_governance.spec.js
+++ b/tests/cypress/tests/Pod_governance.spec.js
@@ -2,12 +2,13 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
 /// <reference types="cypress" />
+import { describeT } from '../support/tagging'
 import { test_genericPolicyGovernance, test_applyPolicyYAML } from '../common/tests'
 
-describe('RHACM4K-1724 - GRC UI: [P1][Sev1][policy-grc] Pod policy governance', () => {
+describeT('RHACM4K-1724 - GRC UI: [P1][Sev1][policy-grc] Pod policy governance', () => {
     test_genericPolicyGovernance('Pod_governance/policy-config.yaml', 'Pod_governance/violations-inform.yaml', 'Pod_governance/violations-enforce.yaml')
 })
 
-describe('GRC UI: [P1][Sev1][policy-grc] Pod policy governance - clean up', () => {
+describeT('GRC UI: [P1][Sev1][policy-grc] Pod policy governance - clean up', () => {
     test_applyPolicyYAML('Pod_governance/Pod_specification_cleanup_policy_raw.yaml')
 })

--- a/tests/cypress/tests/RoleBindingPolicy_governance.spec.js
+++ b/tests/cypress/tests/RoleBindingPolicy_governance.spec.js
@@ -2,12 +2,13 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
 /// <reference types="cypress" />
+import { describeT } from '../support/tagging'
 import { test_genericPolicyGovernance, test_applyPolicyYAML } from '../common/tests'
 
-describe(['extended'], 'RHACM4K-1722 - GRC UI: [P1][Sev1][policy-grc] RoleBindingPolicy governance', () => {
+describeT('@extended RHACM4K-1722 - GRC UI: [P1][Sev1][policy-grc] RoleBindingPolicy governance', () => {
   test_genericPolicyGovernance('RoleBinding_policy_governance/policy-config.yaml', 'RoleBinding_policy_governance/violations-inform.yaml', 'RoleBinding_policy_governance/violations-enforce.yaml')
 })
 
-describe(['extended'], 'GRC UI: [P1][Sev1][policy-grc] RoleBindingPolicy governance - clean up', () => {
+describeT('@extended GRC UI: [P1][Sev1][policy-grc] RoleBindingPolicy governance - clean up', () => {
   test_applyPolicyYAML('RoleBinding_policy_governance/role_binding_specification_cleanup_policy_raw.yaml')
 })

--- a/tests/cypress/tests/RolePolicy_governance.spec.js
+++ b/tests/cypress/tests/RolePolicy_governance.spec.js
@@ -2,12 +2,13 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
 /// <reference types="cypress" />
+import { describeT } from '../support/tagging'
 import { test_genericPolicyGovernance, test_applyPolicyYAML } from '../common/tests'
 
-describe(['extended'], 'RHACM4K-1721 - GRC UI: [P1][Sev1][policy-grc] RolePolicy governance', () => {
+describeT('@extended RHACM4K-1721 - GRC UI: [P1][Sev1][policy-grc] RolePolicy governance', () => {
   test_genericPolicyGovernance('Role_policy_governance/policy-config.yaml', 'Role_policy_governance/violations-inform.yaml', 'Role_policy_governance/violations-enforce.yaml')
 })
 
-describe(['extended'], 'GRC UI: [P1][Sev1][policy-grc] RolePolicy governance - clean up', () => {
+describeT('@extended GRC UI: [P1][Sev1][policy-grc] RolePolicy governance - clean up', () => {
   test_applyPolicyYAML('Role_policy_governance/role_specification_cleanup_policy_raw.yaml')
 })

--- a/tests/cypress/tests/SCCPolicy_governance.spec.js
+++ b/tests/cypress/tests/SCCPolicy_governance.spec.js
@@ -2,12 +2,13 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
 /// <reference types="cypress" />
+import { describeT } from '../support/tagging'
 import { test_genericPolicyGovernance, test_applyPolicyYAML } from '../common/tests'
 
-describe(['extended'], 'RHACM4K-1723 - GRC UI: [P1][Sev1][policy-grc] SecurityContextConstraintsPolicy governance', () => {
+describeT('@extended RHACM4K-1723 - GRC UI: [P1][Sev1][policy-grc] SecurityContextConstraintsPolicy governance', () => {
   test_genericPolicyGovernance('SCC_policy_governance/policy-config.yaml', 'SCC_policy_governance/violations-inform.yaml', 'SCC_policy_governance/violations-enforce.yaml')
 })
 
-describe(['extended'], 'GRC UI: [P1][Sev1][policy-grc] SecurityContextConstraintsPolicy governance - clean up', () => {
+describeT('@extended GRC UI: [P1][Sev1][policy-grc] SecurityContextConstraintsPolicy governance - clean up', () => {
   test_applyPolicyYAML('SCC_policy_governance/SCC_cleanup_policy_raw.yaml')
 })

--- a/tests/cypress/tests/Verify_URLs_for_policy.spec.js
+++ b/tests/cypress/tests/Verify_URLs_for_policy.spec.js
@@ -3,10 +3,11 @@
 
 /// <reference types="cypress" />
 
+import { describeT } from '../support/tagging'
 import { getConfigObject } from '../config'
 import { getDefaultSubstitutionRules } from '../common/views'
 
-describe('RHACM4K-2354 - GRC UI: [P1][Sev1][policy-grc] Check existent and non-existent URLs for the policy', () => {
+describeT('RHACM4K-2354 - GRC UI: [P1][Sev1][policy-grc] Check existent and non-existent URLs for the policy', () => {
   const substitutionRules = getDefaultSubstitutionRules()
   const confFilePolicy = 'duplicatePolicyInDiffNS/create_ns_template.yaml'
   const rawPolicyYAML = getConfigObject(confFilePolicy, 'raw', substitutionRules)

--- a/tests/cypress/tests/all_policies_summary_table.spec.js
+++ b/tests/cypress/tests/all_policies_summary_table.spec.js
@@ -7,9 +7,10 @@
 // other tests running in the environment
 
 /// <reference types="cypress" />
+import { describeT } from '../support/tagging'
 import { getConfigObject } from '../config'
 
-describe('RHACM4K-2343 - [P1][Sev1][policy-grc] All policies page: Verify summary table', () => {
+describeT('RHACM4K-2343 - [P1][Sev1][policy-grc] All policies page: Verify summary table', () => {
 
   const confClusters = getConfigObject('clusters.yaml')
   const clusterCount = Object.keys(confClusters).length

--- a/tests/cypress/tests/create_policy_field_validation.spec.js
+++ b/tests/cypress/tests/create_policy_field_validation.spec.js
@@ -1,7 +1,9 @@
 /* Copyright (c) 2020 Red Hat, Inc. */
 /// <reference types="cypress" />
 
-describe('RHACM4K-2349 - GRC UI: [P1][Sev1][policy-grc] Create policy page: Check policy field validations', () => {
+import { describeT } from '../support/tagging'
+
+describeT('RHACM4K-2349 - GRC UI: [P1][Sev1][policy-grc] Create policy page: Check policy field validations', () => {
 
   const errorMsg = 'Invalid name due to Kubernetes naming restriction.The name must meet the following requirements:• the combined length of namespace and policy name (namespaceName.policyName) should not exceed 63 characters• contain only lowercase alphanumeric characters, \'-\' or \'.\'• start with an alphanumeric character• end with an alphanumeric character'
   const errorMsg2 = 'Invalid name: should only have lowercase alphanumeric characters, \'-\', or \'.\' and not begin or end with punctuation'

--- a/tests/cypress/tests/create_policy_multiselect_sanity.spec.js
+++ b/tests/cypress/tests/create_policy_multiselect_sanity.spec.js
@@ -3,6 +3,7 @@
 
 /// <reference types="cypress" />
 
+import { describeT } from '../support/tagging'
 import { checkItems, verifyItemsChecked } from '../common/views'
 
 const specificationsList = ['CertificatePolicy', 'EtcdEncryption']
@@ -16,7 +17,7 @@ const selectControlsQuery = '.bx--multi-select[aria-label="controls"]'
 const itemQuery = 'input[type="checkbox"]'
 const labelQuery = '.bx--checkbox-label'
 
-describe('RHACM4K-1671 - GRC UI: [P2][Sev2][policy-grc] Test create policy multi-select acts correctly', () => {
+describeT('RHACM4K-1671 - GRC UI: [P2][Sev2][policy-grc] Test create policy multi-select acts correctly', () => {
 
   it('Access the Create policy page', () => {
     cy.FromGRCToCreatePolicyPage()

--- a/tests/cypress/tests/issue2444_empty_namespace_list_in_configurationPolicy.spec.js
+++ b/tests/cypress/tests/issue2444_empty_namespace_list_in_configurationPolicy.spec.js
@@ -2,6 +2,7 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
 /// <reference types="cypress" />
+import { describeT } from '../support/tagging'
 import { getDefaultSubstitutionRules } from '../common/views'
 import { getConfigObject } from '../config'
 
@@ -21,7 +22,7 @@ const confClusterViolations = getConfigObject('issue2444/violations-inform.yaml'
 const clusterViolations = {}
 clusterViolations[clusterList[0]] = confClusterViolations['*']
 
-describe('RHACM4K-1650 - GRC UI: [P1][Sev1][policy-grc] configurationPoicy controller: not matching namespaceSelector issues a violation', () => {
+describeT('RHACM4K-1650 - GRC UI: [P1][Sev1][policy-grc] configurationPoicy controller: not matching namespaceSelector issues a violation', () => {
 
   // create a Pod policy not matching any namespace in namespaceSelector
   it(`Create Pod policy ${policyName} from YAML, expecting a compliance`, () => {

--- a/tests/cypress/tests/issue3677_wrong_namespaceSelector.spec.js
+++ b/tests/cypress/tests/issue3677_wrong_namespaceSelector.spec.js
@@ -2,10 +2,11 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
 /// <reference types="cypress" />
+import { describeT } from '../support/tagging'
 import { getDefaultSubstitutionRules, getViolationsPerPolicy, getViolationsCounter } from '../common/views'
 import { getConfigObject } from '../config'
 
-describe('RHACM4K-1648 - GRC UI: [P2][Sev2][policy-grc] CertPolicy with wrong namespace selector', () => {
+describeT('RHACM4K-1648 - GRC UI: [P2][Sev2][policy-grc] CertPolicy with wrong namespace selector', () => {
 
   const confClusters = getConfigObject('clusters.yaml')
   // we will work only with one cluster, we do not need more

--- a/tests/cypress/tests/issue7520_added_removed_namespaces.spec.js
+++ b/tests/cypress/tests/issue7520_added_removed_namespaces.spec.js
@@ -2,6 +2,7 @@
 /* Copyright Contributors to the Open Cluster Management project */
 
 /// <reference types="cypress" />
+import { describeT } from '../support/tagging'
 import { getDefaultSubstitutionRules,
          verifyPolicyTemplateViolationDetailsForCluster
        } from '../common/views'
@@ -25,7 +26,7 @@ const certPolicyName = uName('cert-policy')
 let substitutionRules
 
 
-describe('RHACM4K-1691 - GRC UI: [P2][Sev2][policy-grc] Certificate policy controller: with wildcard, added or removed namespaces are not detected', () => {
+describeT('RHACM4K-1691 - GRC UI: [P2][Sev2][policy-grc] Certificate policy controller: with wildcard, added or removed namespaces are not detected', () => {
 
   // create namespace ns1
   substitutionRules = [

--- a/tests/cypress/tests/policy_YAML_templates_verification.spec.js
+++ b/tests/cypress/tests/policy_YAML_templates_verification.spec.js
@@ -1,9 +1,10 @@
 /* Copyright (c) 2020 Red Hat, Inc. */
 /// <reference types="cypress" />
 
+import { describeT } from '../support/tagging'
 import { getConfigObject } from '../config'
 
-describe('RHACM4K-2357 - GRC UI: [P1][Sev1][policy-grc] Create policy page: Verify templates', () => {
+describeT('RHACM4K-2357 - GRC UI: [P1][Sev1][policy-grc] Create policy page: Verify templates', () => {
 
 const policyConf = getConfigObject('policy_YAML_templates_verification/policy-config.yaml')
 

--- a/tests/cypress/tests/policy_form_update_per_YAML.spec.js
+++ b/tests/cypress/tests/policy_form_update_per_YAML.spec.js
@@ -1,9 +1,10 @@
 /* Copyright (c) 2020 Red Hat, Inc. */
 /// <reference types="cypress" />
 
+import { describeT } from '../support/tagging'
 import { getConfigObject } from '../config'
 
-describe('RHACM4K-2351 - GRC UI: [P1][Sev1][policy-grc] Create policy page: Updating YAML in editor', () => {
+describeT('RHACM4K-2351 - GRC UI: [P1][Sev1][policy-grc] Create policy page: Updating YAML in editor', () => {
 
 const policyConf = getConfigObject('policy_form_update_per_YAML/policy-config.yaml')
 const rawPolicyYAML = getConfigObject('policy_form_update_per_YAML/policy-raw.yaml', 'raw')

--- a/tests/cypress/tests/verify_YAML_stability.spec.js
+++ b/tests/cypress/tests/verify_YAML_stability.spec.js
@@ -3,6 +3,7 @@
 
 /// <reference types="cypress" />
 
+import { describeT } from '../support/tagging'
 import { getConfigObject } from '../config'
 import { getDefaultSubstitutionRules, parsePolicyNameFromYAML } from '../common/views'
 
@@ -47,7 +48,7 @@ const testPolicy = (policyConfFile, templateConfFile) => {
 
 }
 
-describe('RHACM4K-2509 - GRC UI: [P1][Sev1][policy-grc] All policy page: Verify stability of YAML', () => {
+describeT('RHACM4K-2509 - GRC UI: [P1][Sev1][policy-grc] All policy page: Verify stability of YAML', () => {
 
   testPolicy('verify_YAML_stability/Gatekeeper-template.yaml', 'verify_YAML_stability/Gatekeeper-template-verify.yaml')
   testPolicy('verify_YAML_stability/LimitRange_template-apply.yaml', 'verify_YAML_stability/LimitRange_template-verify.yaml')


### PR DESCRIPTION
Introduces new functions `describeT` and `itT`that are imported from `tests/cypress/support/tagging.js`.
Functions can be used instead of `describe` and `it` and when issued parse tags from the test title and evaluate whether the test should be executed.
Tags are stored directly at the begining of a test title in a format `"@tag1 @tag2 Test title"`, e.g.
`describeT('@mytag This is my test', () => { ...`

Expression to evaluate tags against is obtained from environment variables
`CYPRESS_TAGS_INCLUDE` which is evaluated first, all tests if not defined.
`CYPRESS_TAGS_INCLUDE` reducing the test set obtained in the previous step
These variables should contain a regular expression that is being matched against a list of space separated and alphabetically sorted tags.
Finally, tags from `describeT` are being propagated also to subsequent `itT`, ensuring these steps would be executed (unless excluded)