### PR TITLE
Revert "[release-2.2] "launch cluster" option on cluster violations page should not be available to an imported cluster"

### DIFF
--- a/src-web/components/modules/GrcToggleModule.js
+++ b/src-web/components/modules/GrcToggleModule.js
@@ -168,18 +168,14 @@ class GrcToggleModule extends React.Component {
               }
             )
           }
-          // if consoleURL is unavailable then don't show launch cluster button
-          const removeLaunchCluster = (action.includes('launch.cluster')) && ((row && !row.consoleURL) || (row && row.consoleURL && row.consoleURL === '-'))
-          if (!removeLaunchCluster) {
-            actionsList.push(
-              {
-                title: createDisableTooltip(disableFlag, action, locale, msgs.get(action, locale)),
-                isDisabled: disableFlag ? true : false,
-                onClick: () =>
-                  (disableFlag ? null : getResourceAction(action, row, resourceType))
-              }
-            )
-          }
+          actionsList.push(
+            {
+              title: createDisableTooltip(disableFlag, action, locale, msgs.get(action, locale)),
+              isDisabled: disableFlag ? true : false,
+              onClick: () =>
+                (disableFlag ? null : getResourceAction(action, row, resourceType))
+            }
+          )
         })
       }
     }


### PR DESCRIPTION
Reverts open-cluster-management/grc-ui#548