### PR TITLE
[spec-pod-exists] change nginx image to 1.18.0 that has s390x and ppc64le variants.

### DIFF
--- a/src-web/components/common/templates/spec-pod-exists.yaml
+++ b/src-web/components/common/templates/spec-pod-exists.yaml
@@ -33,7 +33,7 @@ replacements: # if user select this choice, the template variable names and valu
                   name: nginx-pod
                 spec:
                   containers:
-                  - image: nginx:1.7.9
+                  - image: nginx:1.18.0
                     name: nginx
                     ports:
                     - containerPort: 80


### PR DESCRIPTION
Image `nginx:1.7.9` has not ppc64le variant, hence deployment fails on ppc64le spoke clusters.
It pulls the x86 image which results in this error:
`
standard_init_linux.go:219: exec user process caused: exec format error
`
`nginx:1.7.9` was published 5 years ago and is quite outdated.
Please upgrade to `nginx:1.18.0` which is the latest stable release and has s390x and ppc64le support:
https://hub.docker.com/layers/nginx/library/nginx/1.18.0/images/sha256-04e91c9f0b7e645e1eeecfc868ce92b793d7b1e019b0e73156ef3f766c454057