### PR TITLE
check the first icon when running test simutaneously

### DIFF
--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -201,7 +201,7 @@ Cypress.Commands.add('waitForPolicyStatus', (name, violationsCounter) => {
 // optionally can wait for the specific violations counter to appear
 Cypress.Commands.add('waitForClusterViolationsStatus', (name, violationsCounter) => {
   cy.doTableSearch(name)
-    .waitUntil(() => isClusterViolationsStatusAvailable(name, violationsCounter), {'interval': 1000, 'timeout':120000})
+    .waitUntil(() => isClusterViolationsStatusAvailable(name, violationsCounter), {'interval': 1000, 'timeout':240000})
     .clearTableSearch()
 })
 

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -201,7 +201,7 @@ Cypress.Commands.add('waitForPolicyStatus', (name, violationsCounter) => {
 // optionally can wait for the specific violations counter to appear
 Cypress.Commands.add('waitForClusterViolationsStatus', (name, violationsCounter) => {
   cy.doTableSearch(name)
-    .waitUntil(() => isClusterViolationsStatusAvailable(name, violationsCounter), {'interval': 1000, 'timeout':240000})
+    .waitUntil(() => isClusterViolationsStatusAvailable(name, violationsCounter), {'interval': 1000, 'timeout':120000})
     .clearTableSearch()
 })
 

--- a/tests/cypress/support/views.js
+++ b/tests/cypress/support/views.js
@@ -526,7 +526,8 @@ export const isClusterViolationsStatusAvailable = (name, violationsCounter) => {
       cy.get('a').contains(name).parents('td').siblings('td').spread((namespace, counter) => {
         // check the violation status
         cy.wrap(counter).find('path').then((elems) => {
-          if (elems.length === 1) {
+          // when STANDALONE_TESTSUITE_EXECUTION !== FALSE, elems.length could be 2, only check the first icon in such case
+          if (elems.length === 1 || (elems.length === 2 && Cypress.env('STANDALONE_TESTSUITE_EXECUTION') !== 'FALSE')) {
             const d = elems[0].getAttribute('d')
             // M569 seem to be unique to an icon telling that policy status is not available for some cluster
             statusAvailable = !d.startsWith('M569')


### PR DESCRIPTION
Gatekeeper policy was created by another test suite thus we may not have a clean status.
check the first icon when running test simutaneously

https://travis-ci.com/github/open-cluster-management/governance-policy-framework/jobs/498975445#L2368