### PR TITLE
did not use hardcoded namespace when getting the acm route

### DIFF
--- a/build/run-docker-tests.sh
+++ b/build/run-docker-tests.sh
@@ -18,12 +18,13 @@ fi
 
 #Get env from Docker arguments
 export FAIL_FAST=${FAIL_FAST:-false}
-export CYPRESS_BASE_URL=https://`oc get route multicloud-console -n open-cluster-management -o=jsonpath='{.spec.host}'`
+acm_installed_namespace=`oc get subscriptions.operators.coreos.com --all-namespaces | grep advanced-cluster-management | awk '{print $1}'`
+export CYPRESS_BASE_URL=https://`oc get route multicloud-console -n $acm_installed_namespace -o=jsonpath='{.spec.host}'`
 # show all envs
 printenv
 # test oauth server and see if idp has been setup
 i=0
-while true; do 
+while true; do
   IDP=`curl -L -k ${CYPRESS_BASE_URL} | grep ${OC_IDP}` || true
   if [ -z ${IDP// /} ]; then
     echo "wait for idp ${OC_IDP} to take effect..."

--- a/build/run-e2e-tests.sh
+++ b/build/run-e2e-tests.sh
@@ -36,8 +36,9 @@ $DIR/cluster-clean-up.sh managed
 
 echo "Export envs to run e2e"
 export SERVICEACCT_TOKEN=`${BUILD_HARNESS_PATH}/vendor/oc whoami --show-token`
-export headerUrl=https://`oc get route multicloud-console -n open-cluster-management -o=jsonpath='{.spec.host}'`
-export NODE_ENV=development 
+acm_installed_namespace=`oc get subscriptions.operators.coreos.com --all-namespaces | grep advanced-cluster-management | awk '{print $1}'`
+export headerUrl=https://`oc get route multicloud-console -n $acm_installed_namespace -o=jsonpath='{.spec.host}'`
+export NODE_ENV=development
 export API_SERVER_URL=$OC_HUB_CLUSTER_URL
 export OAUTH2_REDIRECT_URL=${OAUTH2_REDIRECT_URL:-"https://localhost:3000/multicloud/policies/auth/callback"}
 export OAUTH2_CLIENT_ID=${OAUTH2_CLIENT_ID:-"multicloudingress"}

--- a/tests/cypress/start_cypress_tests.sh
+++ b/tests/cypress/start_cypress_tests.sh
@@ -49,8 +49,8 @@ fi
 echo -e "\nLogging into Kube API server\n"
 oc login --server=${CYPRESS_OPTIONS_HUB_CLUSTER_URL} -u $CYPRESS_OPTIONS_HUB_USER -p $CYPRESS_OPTIONS_HUB_PASSWORD --insecure-skip-tls-verify
 
-
-RHACM_CONSOLE_URL=https://`oc get route multicloud-console -n open-cluster-management -o=jsonpath='{.spec.host}'`
+acm_installed_namespace=`oc get subscriptions.operators.coreos.com --all-namespaces | grep advanced-cluster-management | awk '{print $1}'`
+RHACM_CONSOLE_URL=https://`oc get route multicloud-console -n $acm_installed_namespace -o=jsonpath='{.spec.host}'`
 export CYPRESS_BASE_URL=${CYPRESS_BASE_URL:-$RHACM_CONSOLE_URL}
 if [ "$CYPRESS_BASE_URL" = "https://localhost:3000" ]; then
   export CYPRESS_coverage=true
@@ -92,9 +92,9 @@ else
 fi
 
 if [ "$NODE_ENV" == "dev" ]; then
-  npx cypress run --browser $BROWSER $HEADLESS --spec "./tests/cypress/tests/*.spec.js" --reporter cypress-multi-reporters  
+  npx cypress run --browser $BROWSER $HEADLESS --spec "./tests/cypress/tests/*.spec.js" --reporter cypress-multi-reporters
 elif [ "$NODE_ENV" == "debug" ]; then
   npx cypress open --browser $BROWSER --config numTestsKeptInMemory=0
-else 
+else
   cypress run --browser $BROWSER $HEADLESS --spec "./tests/cypress/tests/*.spec.js" --reporter cypress-multi-reporters
 fi


### PR DESCRIPTION
I want to running e2e testing within the docker container, but my ACM cluster did not installed in the default namespace `open-cluster-management`, so when running the test, the variable of `CYPRESS_BASE_URL` can not get my multicloud-console route host. so I think we can first check the acm installed namespace before getting the multicloud-console route host.