### PR TITLE
disable coverage by default and enable it in grc-ui travis

### DIFF
--- a/build/run-e2e-tests.sh
+++ b/build/run-e2e-tests.sh
@@ -44,6 +44,7 @@ export OAUTH2_REDIRECT_URL=${OAUTH2_REDIRECT_URL:-"https://localhost:3000/multic
 export OAUTH2_CLIENT_ID=${OAUTH2_CLIENT_ID:-"multicloudingress"}
 export OAUTH2_CLIENT_SECRET=${OAUTH2_CLIENT_SECRET:-"multicloudingresssecret"}
 export CYPRESS_BASE_URL="https://localhost:3000"
+export CYPRESS_coverage=${CYPRESS_coverage:-"true"}
 
 make docker/login
 export DOCKER_URI=quay.io/open-cluster-management/grc-ui-api:${GRCUIAPI_VERSION:-"latest-dev"}

--- a/tests/cypress/start_cypress_tests.sh
+++ b/tests/cypress/start_cypress_tests.sh
@@ -58,13 +58,9 @@ fi
 
 acm_installed_namespace=`oc get subscriptions.operators.coreos.com --all-namespaces | grep advanced-cluster-management | awk '{print $1}'`
 RHACM_CONSOLE_URL=https://`oc get route multicloud-console -n $acm_installed_namespace -o=jsonpath='{.spec.host}'`
-export CYPRESS_BASE_URL=${CYPRESS_BASE_URL:-$RHACM_CONSOLE_URL}
-if [ "$CYPRESS_BASE_URL" == "https://localhost:3000" ] || [ "${CYPRESS_coverage}" != "false" ]; then
-  export CYPRESS_coverage=true
-else
-  export CYPRESS_coverage=false
-fi
 
+export CYPRESS_BASE_URL=${CYPRESS_BASE_URL:-$RHACM_CONSOLE_URL}
+export CYPRESS_coverage=${CYPRESS_coverage:-"false"}
 export CYPRESS_RESOURCE_ID=${CYPRESS_RESOURCE_ID:-"$(date +"%s")"}
 export CYPRESS_RBAC_PASS=$RBAC_PASS
 export CYPRESS_FAIL_FAST_PLUGIN=${CYPRESS_FAIL_FAST_PLUGIN:-"true"}


### PR DESCRIPTION
We don't want to enable coverage by default as it will throw some warning message if test fails in canary
https://travis-ci.com/github/open-cluster-management/canary/jobs/501027732#L808-L812