### PR TITLE
Update cluster list style - 7208

### DIFF
--- a/src-web/components/common/StatusField.js
+++ b/src-web/components/common/StatusField.js
@@ -48,12 +48,12 @@ class StatusField extends React.PureComponent {
       break
     }
     return (
-      <div className='table-status-row'>
-        <div className={`table-status-icon table-status-icon__${className}`}>
+      <span className='table-status-row'>
+        <span className={`table-status-icon table-status-icon__${className}`}>
           {<IconName /> }
-        </div>
-        <p>{this.props.text}</p>
-      </div>
+        </span>
+        <span className='table-status-label'>{this.props.text}</span>
+      </span>
     )
   }
 }

--- a/src-web/containers/App.js
+++ b/src-web/containers/App.js
@@ -5,6 +5,8 @@
 'use strict'
 
 import React from 'react'
+import '../scss/common.scss'
+
 import PropTypes from 'prop-types'
 import { Route, Switch, Redirect, withRouter } from 'react-router-dom'
 import client from '../../server/lib/shared/client'
@@ -19,8 +21,6 @@ import { AcmHeader, AcmRoute } from '@open-cluster-management/ui-components'
 import WelcomeStatic from './Welcome'
 import { getUserAccessData } from '../actions/access'
 import { connect } from 'react-redux'
-
-import '../scss/common.scss'
 
 class App extends React.Component {
 

--- a/src-web/containers/Welcome.js
+++ b/src-web/containers/Welcome.js
@@ -148,7 +148,7 @@ export default class WelcomeStatic extends React.Component {
               <a
                 target='dev-community'
                 href='https://www.redhat.com/en/blog/products'
-                className='bx--link'
+                className='welcome--link'
                 aria-describedby='launchWindow'>
                 {msgs.get(welcomeBoxLinkStr, locale)}
                 <img
@@ -177,7 +177,7 @@ export default class WelcomeStatic extends React.Component {
               <a
                 target='support'
                 href='https://access.redhat.com/support'
-                className='bx--link'
+                className='welcome--link'
                 aria-describedby='launchWindow'>
                 {msgs.get(welcomeBoxLinkStr, locale)}
                 <img

--- a/src-web/scss/common.scss
+++ b/src-web/scss/common.scss
@@ -88,6 +88,10 @@ div.disable-tooltip {
   cursor: not-allowed;
 }
 
+span.table-status-label {
+  padding-left: 0.25rem;
+}
+
 div.no-resource {
   display: flex;
   flex-direction: column;

--- a/src-web/scss/policy-details-overview.scss
+++ b/src-web/scss/policy-details-overview.scss
@@ -108,10 +108,6 @@
                   }
                 }
               }
-              .pf-m-overflow {
-                --pf-c-label__content--Color: var(--pf-global--Color--100);
-                background: var(--pf-global--BackgroundColor--200);
-              }
             }
             &.status-list__nostatus {
               .pf-c-label__content {

--- a/src-web/scss/policy-details-overview.scss
+++ b/src-web/scss/policy-details-overview.scss
@@ -23,62 +23,13 @@
       margin-right: 0.25rem;
     }
   }
-  .overview-content-bottom {
-    .table-status-row p {
-      font-size: .875rem;
-    }
-  }
   .vertical-expend{
     padding: 0 0.5rem;
     width: 100%;
 
       h5.section-title{
-        margin-top: 2rem;
-      }
-
-      .bx--module {
-        padding-left: 0;
-        padding-right: 0;
-      }
-
-      .overview-content-second {
-        display: flex;
-        flex-direction: row;
-        .overview-content-second-cell {
-          display: flex;
-          flex-grow: 1;
-        }
-        .overview-content-second-cell + .overview-content-second-cell {
-          padding-left: 1.25rem;
-        }
-      }
-
-      .module-container{
-        width: 100%;
-      }
-    
-      .bx--module {
-        flex: 1 0 50%;
-        max-width: 100%;
-        min-height: 6.25rem;
-        .bx--module__inner {
-          min-height: 6.25rem ;
-          flex: 1 0 50%;
-          position: relative;
-          overflow: auto;
-          .bx--module__content {
-            .bx--structured-list-tbody{
-              .bx--structured-list-row {
-                .bx--structured-list-td:nth-child(2) {
-                  word-wrap: break-word;
-                }
-              }
-            }
-          }
-          .bx--structured-list-th:first-child {
-            min-width: 9.375rem;
-          }
-        }
+        margin: 2rem 0 1rem 0;
+        font-weight: var(--pf-global--FontWeight--bold);
       }
 
       // Accordion panel containing policy details
@@ -117,54 +68,31 @@
         }
       }
 
-      .overview-content-bottom {
-        width: 100%;
-        flex: 1 0 100%;
-        .bx--module__inner{
-          border: 0;
-        .bx--module__content{
-          padding: 0;
-          height: 100%;
-          .simple-table{
-            height: 100%;
-            p {
-              font-size: .875rem;
-            }
-            .resource-table-expandable-cell{
-              table{
-                border-style: hidden;
-              }
-              thead{
-                background-color: white;
-              }
-              th{
-                span{
-                  color: $color__blue-51;
-                }
-                border: 0.0625rem solid $color__gray-1;
-                border-left: hidden;
-                font-size: .75rem;
-                padding-left: 0;
-              }
-              td{
-                border: 0.0625rem solid $color__gray-1;
-                border-left: hidden;
-                font-size: .75rem;
-                padding-left: 0;
-                .textWithTruncation {
-                  font-size: .75rem;
-                }
-              }
-            }
-          }
-          .bx--data-table-v2-container{
-            padding: 0;
-            .bx--data-table-v2{
-              border: 0;
-            }
-          }
+      // Cluster placement table
+      .cluster-list {
+        margin-bottom: 4rem;
+
+        * {
+          font-size: 0.875rem;
         }
         
+        .pf-c-table__button {
+          margin: 0;
+        }
+        
+        .status-container {
+          .status-heading {
+            font-weight: var(--pf-global--FontWeight--semi-bold);
+          }
+
+          .status-list {
+            .pf-c-label-group__list {
+              max-height: 10.25rem;
+              min-height: 2.15rem;
+              overflow-x: hidden;
+              overflow-y: auto;
+            }
+          }
         }
       }
 
@@ -193,13 +121,7 @@
       &-right {
         flex: 2 2 40%;
         float: right;
-  
-      }
-  
-      .bx--module {
-        min-height: 25rem;
-        min-width: 40%;
-      }
+      }  
     }
 
     &-bottom {
@@ -210,6 +132,5 @@
     li { margin-bottom: .3rem; }
     code { font-size: .6rem; }
 
-    .bx--snippet.bx--snippet--code { margin-bottom: .3rem; }
   }
 }

--- a/src-web/scss/policy-details-overview.scss
+++ b/src-web/scss/policy-details-overview.scss
@@ -42,7 +42,7 @@
           padding: 0;
 
           .pf-c-description-list {
-            color: #151515;
+            color: var(--pf-global--Color--100);
             margin: 1.5rem;
             width: 50%;
 
@@ -91,6 +91,35 @@
               min-height: 2.15rem;
               overflow-x: hidden;
               overflow-y: auto;
+
+              .pf-c-label-group__list-item :not(.pf-m-overflow) {
+                margin: 0;
+
+                .pf-c-label {
+                  padding: 0.25rem 0 0 0;
+
+                  .pf-c-label__content {
+                    &:hover {
+                      text-decoration: underline;
+                    }
+                    &::before {
+                      border: 0;
+                    }
+                  }
+                }
+              }
+              .pf-m-overflow {
+                --pf-c-label__content--Color: var(--pf-global--Color--100);
+                background: var(--pf-global--BackgroundColor--200);
+              }
+            }
+            &.status-list__nostatus {
+              .pf-c-label__content {
+                &:hover {
+                  text-decoration: none !important;
+                  cursor: unset;
+                }
+              }
             }
           }
         }
@@ -129,7 +158,6 @@
       flex: 1 0 100%;
     }
     b { font-weight: bold; }
-    li { margin-bottom: .3rem; }
     code { font-size: .6rem; }
 
   }

--- a/src-web/scss/welcome.scss
+++ b/src-web/scss/welcome.scss
@@ -298,7 +298,7 @@
           margin-left: 6px;
           color: #2A78E0;
         }
-        .bx--link {
+        .welcome--link {
           display: flex;
           align-items: center;
           line-height: 2;

--- a/src-web/tableDefinitions/hcm-compliances.js
+++ b/src-web/tableDefinitions/hcm-compliances.js
@@ -406,12 +406,12 @@ export function getDecisionList(policy, locale) {
         <span key={`${status}-status-heading`} className='status-heading'>
           <StatusField status={status} text={`${statusMsg}: `} />
         </span>
-        <span key={`${status}-status-list`} className='status-list'>
+        <span key={`${status}-status-list`} className={`status-list status-list__${status}`}>
           <LabelGroup
-            collapsedText='+${remaining}'
+            collapsedText='${remaining} more'
             numLabels='5'
           >
-            {Array.from(clusterList[status]).map((cluster) =>{
+            {Array.from(clusterList[status]).map((cluster, index) =>{
                 // If there's no status, there's no point in linking to the status page
                 let href=null, color='grey'
                 if (status !== 'nostatus') {
@@ -432,7 +432,7 @@ export function getDecisionList(policy, locale) {
                         componentRef
                       })=>
                         <Link to={href} className={className} innerRef={componentRef}>
-                          {content}
+                          {content}{index < clusterList[status].size - 1 && ', '}
                         </Link>
                     }
                   >

--- a/src-web/tableDefinitions/hcm-compliances.js
+++ b/src-web/tableDefinitions/hcm-compliances.js
@@ -20,7 +20,7 @@ import { Link } from 'react-router-dom'
 import StatusField from '../components/common/StatusField'
 import { Label, LabelGroup } from '@patternfly/react-core'
 import config from '../../server/lib/shared/config'
-import { wrappable, sortable, breakWord } from '@patternfly/react-table'
+import { wrappable, breakWord } from '@patternfly/react-table'
 
 export default {
   defaultSortField: 'metadata.name',
@@ -63,7 +63,7 @@ export default {
       {
         key: 'clusterSelector',
         resourceKey: 'placementPolicies',
-        transforms: [wrappable, sortable],
+        transforms: [wrappable],
         cellTransforms: [breakWord],
         msgKey: 'table.header.cluster.selector',
         transformFunction: getLabels,
@@ -71,7 +71,7 @@ export default {
       {
         key: 'cluster',
         resourceKey: 'clusters',
-        transforms: [wrappable, sortable],
+        transforms: [wrappable],
         cellTransforms: [breakWord],
         msgKey: 'table.header.clusters',
         transformFunction: getDecisionCount,
@@ -369,6 +369,16 @@ export function getDecisionCount(item = {}){
 export function getDecisionList(policy, locale) {
   // Gather full cluster list from placementPolicy status
   const fullClusterList = _.get(policy, 'placementPolicies[0].status.decisions', [])
+    .flatMap((item)=>{
+      const policyArray = []
+      for (let i = 2; i < 100; i++) {
+        policyArray.push({
+          clusterName: `${item.clusterName}${i}`,
+          clusterNamespace: `${item.clusterNamespace}${i}`,
+        })
+      }
+      return [item, ...policyArray]
+    })
   // Gather status list from policy status
   const rawStatusList = _.get(policy, 'raw.status.status', [])
   // Build lists of clusters, organized by status keys
@@ -403,10 +413,10 @@ export function getDecisionList(policy, locale) {
     const statusMsg = msgs.get(`table.cell.${status}`, locale)
     statusList.push(
       <div key={`${status}-status-container`} className='status-container'>
-        <div key={`${status}-status-heading`} className='status-heading'>
-          <StatusField status={status} text={`${statusMsg}:`} />
-        </div>
-        <div key={`${status}-status-list`} className='status-list'>
+        <span key={`${status}-status-heading`} className='status-heading'>
+          <StatusField status={status} text={`${statusMsg}: `} />
+        </span>
+        <span key={`${status}-status-list`} className='status-list'>
           <LabelGroup
             collapsedText='+${remaining}'
             numLabels='5'
@@ -442,7 +452,7 @@ export function getDecisionList(policy, locale) {
               })
             }
           </LabelGroup>
-        </div>
+        </span>
       </div>
     )
   }

--- a/src-web/tableDefinitions/hcm-compliances.js
+++ b/src-web/tableDefinitions/hcm-compliances.js
@@ -369,16 +369,6 @@ export function getDecisionCount(item = {}){
 export function getDecisionList(policy, locale) {
   // Gather full cluster list from placementPolicy status
   const fullClusterList = _.get(policy, 'placementPolicies[0].status.decisions', [])
-    .flatMap((item)=>{
-      const policyArray = []
-      for (let i = 2; i < 100; i++) {
-        policyArray.push({
-          clusterName: `${item.clusterName}${i}`,
-          clusterNamespace: `${item.clusterNamespace}${i}`,
-        })
-      }
-      return [item, ...policyArray]
-    })
   // Gather status list from policy status
   const rawStatusList = _.get(policy, 'raw.status.status', [])
   // Build lists of clusters, organized by status keys

--- a/tests/cypress/support/views.js
+++ b/tests/cypress/support/views.js
@@ -1082,7 +1082,7 @@ export const action_verifyClusterListInPolicyDetails = (policyConfig, clusterVio
             cy.wrap(status).within(() => {
               // find cluster name
               cy.get('a').contains(clusterName).as('clusterStatus').should('have.text', clusterName)
-              cy.get('@clusterStatus').parents('div.status-list').siblings('div.status-heading').get('.table-status-row').children().spread((icon, status) => {
+              cy.get('@clusterStatus').parents('.status-list').siblings('.status-heading').get('.table-status-row').children().spread((icon, status) => {
                 // check status
                 const clusterStatusExp = getClusterPolicyStatus(clusterViolations[clusterName])
                 const clusterStatus = new RegExp(`^${clusterStatusExp}[:]`)

--- a/tests/jest/components/common/__snapshots__/StatusField.test.js.snap
+++ b/tests/jest/components/common/__snapshots__/StatusField.test.js.snap
@@ -1,10 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`StatusField renders default as expected 1`] = `
-<div
+<span
   className="table-status-row"
 >
-  <div
+  <span
     className="table-status-icon table-status-icon__unknown"
   >
     <svg
@@ -25,18 +25,20 @@ exports[`StatusField renders default as expected 1`] = `
         d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
       />
     </svg>
-  </div>
-  <p>
+  </span>
+  <span
+    className="table-status-label"
+  >
     TextStringDefault
-  </p>
-</div>
+  </span>
+</span>
 `;
 
 exports[`StatusField renders failed as expected 1`] = `
-<div
+<span
   className="table-status-row"
 >
-  <div
+  <span
     className="table-status-icon table-status-icon__failed"
   >
     <svg
@@ -57,18 +59,20 @@ exports[`StatusField renders failed as expected 1`] = `
         d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
       />
     </svg>
-  </div>
-  <p>
+  </span>
+  <span
+    className="table-status-label"
+  >
     TextStringFailed
-  </p>
-</div>
+  </span>
+</span>
 `;
 
 exports[`StatusField renders ok as expected 1`] = `
-<div
+<span
   className="table-status-row"
 >
-  <div
+  <span
     className="table-status-icon table-status-icon__ok"
   >
     <svg
@@ -89,18 +93,20 @@ exports[`StatusField renders ok as expected 1`] = `
         d="M504 256c0 136.967-111.033 248-248 248S8 392.967 8 256 119.033 8 256 8s248 111.033 248 248zM227.314 387.314l184-184c6.248-6.248 6.248-16.379 0-22.627l-22.627-22.627c-6.248-6.249-16.379-6.249-22.628 0L216 308.118l-70.059-70.059c-6.248-6.248-16.379-6.248-22.628 0l-22.627 22.627c-6.248 6.248-6.248 16.379 0 22.627l104 104c6.249 6.249 16.379 6.249 22.628.001z"
       />
     </svg>
-  </div>
-  <p>
+  </span>
+  <span
+    className="table-status-label"
+  >
     TextStringOK
-  </p>
-</div>
+  </span>
+</span>
 `;
 
 exports[`StatusField renders warning as expected 1`] = `
-<div
+<span
   className="table-status-row"
 >
-  <div
+  <span
     className="table-status-icon table-status-icon__warning"
   >
     <svg
@@ -121,9 +127,11 @@ exports[`StatusField renders warning as expected 1`] = `
         d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
       />
     </svg>
-  </div>
-  <p>
+  </span>
+  <span
+    className="table-status-label"
+  >
     TextStringWarning
-  </p>
-</div>
+  </span>
+</span>
 `;

--- a/tests/jest/components/modules/__snapshots__/PolicyDetailsOverview.test.js.snap
+++ b/tests/jest/components/modules/__snapshots__/PolicyDetailsOverview.test.js.snap
@@ -447,7 +447,7 @@ exports[`PolicyDetailsOverview component renders a cluster list expander with mo
                     </span>
                   </span>
                   <span
-                    className="status-list"
+                    className="status-list status-list__nostatus"
                   >
                     <div
                       className="pf-c-label-group"
@@ -474,6 +474,7 @@ exports[`PolicyDetailsOverview component renders a cluster list expander with mo
                                   onClick={[Function]}
                                 >
                                   calamari
+                                  , 
                                 </a>
                               </span>
                             </span>
@@ -491,6 +492,7 @@ exports[`PolicyDetailsOverview component renders a cluster list expander with mo
                                   onClick={[Function]}
                                 >
                                   cluster1
+                                  , 
                                 </a>
                               </span>
                             </span>
@@ -508,6 +510,7 @@ exports[`PolicyDetailsOverview component renders a cluster list expander with mo
                                   onClick={[Function]}
                                 >
                                   cluster2
+                                  , 
                                 </a>
                               </span>
                             </span>
@@ -525,6 +528,7 @@ exports[`PolicyDetailsOverview component renders a cluster list expander with mo
                                   onClick={[Function]}
                                 >
                                   cluster3
+                                  , 
                                 </a>
                               </span>
                             </span>
@@ -542,6 +546,7 @@ exports[`PolicyDetailsOverview component renders a cluster list expander with mo
                                   onClick={[Function]}
                                 >
                                   cluster4
+                                  , 
                                 </a>
                               </span>
                             </span>
@@ -556,7 +561,7 @@ exports[`PolicyDetailsOverview component renders a cluster list expander with mo
                               <span
                                 className="pf-c-label__content"
                               >
-                                +1
+                                1 more
                               </span>
                             </button>
                           </li>
@@ -1020,7 +1025,7 @@ exports[`PolicyDetailsOverview component renders as normal 1`] = `
                     </span>
                   </span>
                   <span
-                    className="status-list"
+                    className="status-list status-list__nostatus"
                   >
                     <div
                       className="pf-c-label-group"

--- a/tests/jest/components/modules/__snapshots__/PolicyDetailsOverview.test.js.snap
+++ b/tests/jest/components/modules/__snapshots__/PolicyDetailsOverview.test.js.snap
@@ -346,98 +346,22 @@ exports[`PolicyDetailsOverview component renders a cluster list expander with mo
               hidden={false}
             >
               <th
-                aria-sort="ascending"
-                className="pf-m-wrap pf-c-table__sort pf-m-selected"
+                className="pf-m-wrap"
                 data-key={0}
                 data-label="Cluster selector"
                 onMouseEnter={[Function]}
                 scope="col"
               >
-                <button
-                  className="pf-c-table__button"
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <div
-                    className="pf-c-table__button-content"
-                  >
-                    <span
-                      className="pf-c-table__text"
-                      onMouseEnter={[Function]}
-                    >
-                      Cluster selector
-                    </span>
-                    <span
-                      className="pf-c-table__sort-indicator"
-                    >
-                      <svg
-                        aria-hidden={true}
-                        aria-labelledby={null}
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        style={
-                          Object {
-                            "verticalAlign": "-0.125em",
-                          }
-                        }
-                        viewBox="0 0 256 512"
-                        width="1em"
-                      >
-                        <path
-                          d="M88 166.059V468c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12V166.059h46.059c21.382 0 32.09-25.851 16.971-40.971l-86.059-86.059c-9.373-9.373-24.569-9.373-33.941 0l-86.059 86.059c-15.119 15.119-4.411 40.971 16.971 40.971H88z"
-                        />
-                      </svg>
-                    </span>
-                  </div>
-                </button>
+                Cluster selector
               </th>
               <th
-                aria-sort="none"
-                className="pf-m-wrap pf-c-table__sort"
+                className="pf-m-wrap"
                 data-key={1}
                 data-label="Clusters"
                 onMouseEnter={[Function]}
                 scope="col"
               >
-                <button
-                  className="pf-c-table__button"
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <div
-                    className="pf-c-table__button-content"
-                  >
-                    <span
-                      className="pf-c-table__text"
-                      onMouseEnter={[Function]}
-                    >
-                      Clusters
-                    </span>
-                    <span
-                      className="pf-c-table__sort-indicator"
-                    >
-                      <svg
-                        aria-hidden={true}
-                        aria-labelledby={null}
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        style={
-                          Object {
-                            "verticalAlign": "-0.125em",
-                          }
-                        }
-                        viewBox="0 0 256 512"
-                        width="1em"
-                      >
-                        <path
-                          d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
-                        />
-                      </svg>
-                    </span>
-                  </div>
-                </button>
+                Clusters
               </th>
               <th
                 className="pf-m-wrap"
@@ -487,13 +411,13 @@ exports[`PolicyDetailsOverview component renders a cluster list expander with mo
                 <div
                   className="status-container"
                 >
-                  <div
+                  <span
                     className="status-heading"
                   >
-                    <div
+                    <span
                       className="table-status-row"
                     >
-                      <div
+                      <span
                         className="table-status-icon table-status-icon__nostatus"
                       >
                         <svg
@@ -514,13 +438,15 @@ exports[`PolicyDetailsOverview component renders a cluster list expander with mo
                             d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
                           />
                         </svg>
-                      </div>
-                      <p>
-                        No status:
-                      </p>
-                    </div>
-                  </div>
-                  <div
+                      </span>
+                      <span
+                        className="table-status-label"
+                      >
+                        No status: 
+                      </span>
+                    </span>
+                  </span>
+                  <span
                     className="status-list"
                   >
                     <div
@@ -637,7 +563,7 @@ exports[`PolicyDetailsOverview component renders a cluster list expander with mo
                         </ul>
                       </div>
                     </div>
-                  </div>
+                  </span>
                 </div>
               </td>
             </tr>
@@ -993,98 +919,22 @@ exports[`PolicyDetailsOverview component renders as normal 1`] = `
               hidden={false}
             >
               <th
-                aria-sort="ascending"
-                className="pf-m-wrap pf-c-table__sort pf-m-selected"
+                className="pf-m-wrap"
                 data-key={0}
                 data-label="Cluster selector"
                 onMouseEnter={[Function]}
                 scope="col"
               >
-                <button
-                  className="pf-c-table__button"
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <div
-                    className="pf-c-table__button-content"
-                  >
-                    <span
-                      className="pf-c-table__text"
-                      onMouseEnter={[Function]}
-                    >
-                      Cluster selector
-                    </span>
-                    <span
-                      className="pf-c-table__sort-indicator"
-                    >
-                      <svg
-                        aria-hidden={true}
-                        aria-labelledby={null}
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        style={
-                          Object {
-                            "verticalAlign": "-0.125em",
-                          }
-                        }
-                        viewBox="0 0 256 512"
-                        width="1em"
-                      >
-                        <path
-                          d="M88 166.059V468c0 6.627 5.373 12 12 12h56c6.627 0 12-5.373 12-12V166.059h46.059c21.382 0 32.09-25.851 16.971-40.971l-86.059-86.059c-9.373-9.373-24.569-9.373-33.941 0l-86.059 86.059c-15.119 15.119-4.411 40.971 16.971 40.971H88z"
-                        />
-                      </svg>
-                    </span>
-                  </div>
-                </button>
+                Cluster selector
               </th>
               <th
-                aria-sort="none"
-                className="pf-m-wrap pf-c-table__sort"
+                className="pf-m-wrap"
                 data-key={1}
                 data-label="Clusters"
                 onMouseEnter={[Function]}
                 scope="col"
               >
-                <button
-                  className="pf-c-table__button"
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <div
-                    className="pf-c-table__button-content"
-                  >
-                    <span
-                      className="pf-c-table__text"
-                      onMouseEnter={[Function]}
-                    >
-                      Clusters
-                    </span>
-                    <span
-                      className="pf-c-table__sort-indicator"
-                    >
-                      <svg
-                        aria-hidden={true}
-                        aria-labelledby={null}
-                        fill="currentColor"
-                        height="1em"
-                        role="img"
-                        style={
-                          Object {
-                            "verticalAlign": "-0.125em",
-                          }
-                        }
-                        viewBox="0 0 256 512"
-                        width="1em"
-                      >
-                        <path
-                          d="M214.059 377.941H168V134.059h46.059c21.382 0 32.09-25.851 16.971-40.971L144.971 7.029c-9.373-9.373-24.568-9.373-33.941 0L24.971 93.088c-15.119 15.119-4.411 40.971 16.971 40.971H88v243.882H41.941c-21.382 0-32.09 25.851-16.971 40.971l86.059 86.059c9.373 9.373 24.568 9.373 33.941 0l86.059-86.059c15.12-15.119 4.412-40.971-16.97-40.971z"
-                        />
-                      </svg>
-                    </span>
-                  </div>
-                </button>
+                Clusters
               </th>
               <th
                 className="pf-m-wrap"
@@ -1134,13 +984,13 @@ exports[`PolicyDetailsOverview component renders as normal 1`] = `
                 <div
                   className="status-container"
                 >
-                  <div
+                  <span
                     className="status-heading"
                   >
-                    <div
+                    <span
                       className="table-status-row"
                     >
-                      <div
+                      <span
                         className="table-status-icon table-status-icon__nostatus"
                       >
                         <svg
@@ -1161,13 +1011,15 @@ exports[`PolicyDetailsOverview component renders as normal 1`] = `
                             d="M569.517 440.013C587.975 472.007 564.806 512 527.94 512H48.054c-36.937 0-59.999-40.055-41.577-71.987L246.423 23.985c18.467-32.009 64.72-31.951 83.154 0l239.94 416.028zM288 354c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
                           />
                         </svg>
-                      </div>
-                      <p>
-                        No status:
-                      </p>
-                    </div>
-                  </div>
-                  <div
+                      </span>
+                      <span
+                        className="table-status-label"
+                      >
+                        No status: 
+                      </span>
+                    </span>
+                  </span>
+                  <span
                     className="status-list"
                   >
                     <div
@@ -1202,7 +1054,7 @@ exports[`PolicyDetailsOverview component renders as normal 1`] = `
                         </ul>
                       </div>
                     </div>
-                  </div>
+                  </span>
                 </div>
               </td>
             </tr>

--- a/tests/jest/containers/__snapshots__/Welcome.test.js.snap
+++ b/tests/jest/containers/__snapshots__/Welcome.test.js.snap
@@ -355,7 +355,7 @@ exports[`Welcome component renders as expected 1`] = `
         </p>
         <a
           aria-describedby="launchWindow"
-          className="bx--link"
+          className="welcome--link"
           href="https://www.redhat.com/en/blog/products"
           target="dev-community"
         >
@@ -411,7 +411,7 @@ exports[`Welcome component renders as expected 1`] = `
         </p>
         <a
           aria-describedby="launchWindow"
-          className="bx--link"
+          className="welcome--link"
           href="https://access.redhat.com/support"
           target="support"
         >


### PR DESCRIPTION
- Makes the Cluster status list scrollable when expanded
- Removes unused table column sorting

![cluster-list](https://user-images.githubusercontent.com/19750917/116154112-419d0400-a6b6-11eb-9f44-d0110b013c5f.gif)

Addresses https://github.com/open-cluster-management/backlog/issues/7208