### PR TITLE
fix multi-line yaml handling and parsing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22254,8 +22254,7 @@
         },
         "ssri": {
           "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/ssri/-/ssri-6.0.1.tgz",
-          "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
+          "resolved": "",
           "requires": {
             "figgy-pudding": "^3.5.1"
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3462,6 +3462,15 @@
         "nyc": "15.1.0"
       },
       "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "dev": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
         "debug": {
           "version": "4.3.1",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
@@ -3516,6 +3525,16 @@
           "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
           "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
           "dev": true
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
         },
         "npm-run-path": {
           "version": "4.0.1",
@@ -3676,6 +3695,14 @@
             "uri-js": "^4.2.2"
           }
         },
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
         "globals": {
           "version": "12.4.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
@@ -3688,6 +3715,15 @@
           "version": "4.0.6",
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
           "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
         },
         "type-fest": {
           "version": "0.8.1",
@@ -3713,6 +3749,14 @@
         "resolve-from": "^5.0.0"
       },
       "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
         "camelcase": {
           "version": "5.3.1",
           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -3725,6 +3769,15 @@
           "requires": {
             "locate-path": "^5.0.0",
             "path-exists": "^4.0.0"
+          }
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
           }
         },
         "locate-path": {
@@ -5321,12 +5374,9 @@
       }
     },
     "argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "requires": {
-        "sprintf-js": "~1.0.2"
-      }
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "aria-query": {
       "version": "4.2.2",
@@ -7590,6 +7640,14 @@
         "parse-json": "^4.0.0"
       },
       "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
         "import-fresh": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-2.0.0.tgz",
@@ -7597,6 +7655,15 @@
           "requires": {
             "caller-path": "^2.0.0",
             "resolve-from": "^3.0.0"
+          }
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
           }
         },
         "parse-json": {
@@ -9159,6 +9226,14 @@
             "color-convert": "^2.0.1"
           }
         },
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
         "chalk": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
@@ -9203,6 +9278,15 @@
           "version": "4.0.6",
           "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
           "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg=="
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
         },
         "semver": {
           "version": "7.3.5",
@@ -13834,6 +13918,27 @@
       "requires": {
         "flat": "^4.0.0",
         "js-yaml": "^3.9.1"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "dev": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        }
       }
     },
     "js-base64": {
@@ -13853,12 +13958,11 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
       "requires": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
+        "argparse": "^2.0.1"
       }
     },
     "js-yaml-loader": {
@@ -13870,6 +13974,27 @@
         "js-yaml": "^3.13.1",
         "loader-utils": "^1.2.3",
         "un-eval": "^1.2.0"
+      },
+      "dependencies": {
+        "argparse": {
+          "version": "1.0.10",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+          "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+          "dev": true,
+          "requires": {
+            "sprintf-js": "~1.0.2"
+          }
+        },
+        "js-yaml": {
+          "version": "3.14.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+          "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+          "dev": true,
+          "requires": {
+            "argparse": "^1.0.7",
+            "esprima": "^4.0.0"
+          }
+        }
       }
     },
     "jsbn": {

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "helmet": "^3.23.3",
     "http-proxy-middleware": "^1.1.1",
     "ignore-styles": "^5.0.1",
-    "js-yaml": "^3.14.1",
+    "js-yaml": "^4.1.0",
     "lodash": "^4.17.21",
     "log4js": "^6.3.0",
     "mime-types": "^2.1.30",

--- a/src-web/components/common/TemplateEditor/utils/update-controls.js
+++ b/src-web/components/common/TemplateEditor/utils/update-controls.js
@@ -286,7 +286,7 @@ export const dumpYAMLFromTemplateObject = (templateObject) => {
       if (yaml !== '') {
         yaml += '---\n'
       }
-      yaml += jsYaml.dump(obj.$raw)
+      yaml += jsYaml.dump(obj.$raw, {lineWidth: -1})
     })
   })
   return yaml
@@ -295,17 +295,17 @@ export const dumpYAMLFromPolicyDiscovered = (policyDiscovered) => {
   let yaml = ''
   const policy = policyDiscovered.policy
   if (policy) {
-    yaml = jsYaml.dump(policy) + '\n'
+    yaml = jsYaml.dump(policy, {lineWidth: -1}) + '\n'
   }
   const placementbindings = policyDiscovered.placementBindings
   placementbindings.map(pb=>{
     yaml += '---\n'
-    yaml += jsYaml.dump(pb.raw)
+    yaml += jsYaml.dump(pb.raw, {lineWidth: -1})
   })
   const placementrules = policyDiscovered.placementPolicies
   placementrules.map(plr=>{
     yaml += '---\n'
-    yaml += jsYaml.dump(plr.raw)
+    yaml += jsYaml.dump(plr.raw, {lineWidth: -1})
   })
   return yaml
 }
@@ -318,7 +318,7 @@ export const parseYAML = (yaml) => {
   // check for syntax errors
   try {
     yamls.forEach((snip)=>{
-      const obj = jsYaml.safeLoad(snip)
+      const obj = jsYaml.load(snip)
       const key = _.get(obj, 'kind', 'unknown')
       let values = parsed[key]
       if (!values) {

--- a/src-web/components/common/TemplateEditor/utils/update-editor.js
+++ b/src-web/components/common/TemplateEditor/utils/update-editor.js
@@ -129,7 +129,9 @@ export const generateYAML = (template, controlData) => {
     // Only process if it's valid, otherwise throw it out
     if (parsed['parsed']['unknown']) {
       const raw = parsed['parsed']['unknown'][0]['$raw']
-      templateData['specsCapture'] = jsYaml.safeDump(raw)
+      console.log(raw)
+      templateData['specsCapture'] = jsYaml.dump(raw, {lineWidth: -1})
+      console.log(templateData.specsCapture)
     } else {
       templateData['specsCapture'] = []
     }

--- a/src-web/components/common/TemplateEditor/utils/update-editor.js
+++ b/src-web/components/common/TemplateEditor/utils/update-editor.js
@@ -129,9 +129,7 @@ export const generateYAML = (template, controlData) => {
     // Only process if it's valid, otherwise throw it out
     if (parsed['parsed']['unknown']) {
       const raw = parsed['parsed']['unknown'][0]['$raw']
-      console.log(raw)
       templateData['specsCapture'] = jsYaml.dump(raw, {lineWidth: -1})
-      console.log(templateData.specsCapture)
     } else {
       templateData['specsCapture'] = []
     }

--- a/src-web/components/common/TemplateEditor/utils/update-editor.js
+++ b/src-web/components/common/TemplateEditor/utils/update-editor.js
@@ -135,7 +135,6 @@ export const generateYAML = (template, controlData) => {
     }
   }
   let yaml = template(templateData) || ''
-  yaml = yaml.replace(/[\r\n]+/g, '\n')
 
   // find indent of key and indent the whole snippet
   Object.entries(snippetMap).forEach(([key, replace]) => {

--- a/src-web/components/modules/PolicyTemplateDetailsView.js
+++ b/src-web/components/modules/PolicyTemplateDetailsView.js
@@ -115,7 +115,7 @@ class PolicyTemplateDetailsView extends React.Component {
                 height={'500px'}
                 readOnly
                 setEditor={this.setEditor}
-                yaml={jsYaml.safeDump(items)} />
+                yaml={jsYaml.dump(items, {lineWidth: -1})} />
             </div>
           </div>
         </div>

--- a/tests/cypress/config/policy_YAML_templates_verification/GatekeeperOperator-raw.yaml
+++ b/tests/cypress/config/policy_YAML_templates_verification/GatekeeperOperator-raw.yaml
@@ -53,7 +53,7 @@ spec:
                     logLevel: INFO
                     replicas: 1
                   image:
-                    image: 'registry.redhat.io/rhacm2/gatekeeper-rhel8:v3.3.0'
+                    image: registry.redhat.io/rhacm2/gatekeeper-rhel8:v3.3.0
                   validatingWebhook: Enabled
                   mutatingWebhook: Disabled
                   webhook:

--- a/tests/cypress/config/policy_YAML_templates_verification/Pod-raw.yaml
+++ b/tests/cypress/config/policy_YAML_templates_verification/Pod-raw.yaml
@@ -33,7 +33,7 @@ spec:
                   name: nginx-pod
                 spec:
                   containers:
-                    - image: 'nginx:1.18.0'
+                    - image: nginx:1.18.0
                       name: nginx
                       ports:
                         - containerPort: 80

--- a/tests/cypress/config/policy_YAML_templates_verification/SecurityContextConstraints-raw.yaml
+++ b/tests/cypress/config/policy_YAML_templates_verification/SecurityContextConstraints-raw.yaml
@@ -31,11 +31,7 @@ spec:
                 kind: SecurityContextConstraints
                 metadata:
                   annotations:
-                    kubernetes.io/description: >-
-                      restricted denies access to all host features and requires
-                      pods to be run with a UID, and SELinux context that are
-                      allocated to the namespace.  This is the most restrictive
-                      SCC and it is used by default for authenticated users.
+                    kubernetes.io/description: restricted denies access to all host features and requires pods to be run with a UID, and SELinux context that are allocated to the namespace.  This is the most restrictive SCC and it is used by default for authenticated users.
                   name: restricted-scc
                 allowHostDirVolumePlugin: false
                 allowHostIPC: false
@@ -49,7 +45,7 @@ spec:
                 fsGroup:
                   type: MustRunAs
                 groups:
-                  - 'system:authenticated'
+                  - system:authenticated
                 priority: 10
                 readOnlyRootFilesystem: false
                 requiredDropCapabilities:

--- a/tests/cypress/config/verify_YAML_stability/Gatekeeper-template-verify.yaml
+++ b/tests/cypress/config/verify_YAML_stability/Gatekeeper-template-verify.yaml
@@ -38,11 +38,9 @@ spec:
                               items: string
                   targets:
                     - target: admission.k8s.gatekeeper.sh
-                      rego: >
+                      rego: |
                         package k8srequiredlabels
-
-                        violation[{"msg": msg, "details": {"missing_labels":
-                        missing}}] {
+                        violation[{"msg": msg, "details": {"missing_labels": missing}}] {
                           provided := {label | input.review.object.metadata.labels[label]}
                           required := {label | label := input.parameters.labels[_]}
                           missing := required - provided

--- a/tests/cypress/config/verify_YAML_stability/Gatekeeper-template-verify.yaml
+++ b/tests/cypress/config/verify_YAML_stability/Gatekeeper-template-verify.yaml
@@ -39,8 +39,10 @@ spec:
                   targets:
                     - target: admission.k8s.gatekeeper.sh
                       rego: >
-                        package k8srequiredlabels violation[{"msg": msg,
-                        "details": {"missing_labels": missing}}] {
+                        package k8srequiredlabels
+
+                        violation[{"msg": msg, "details": {"missing_labels":
+                        missing}}] {
                           provided := {label | input.review.object.metadata.labels[label]}
                           required := {label | label := input.parameters.labels[_]}
                           missing := required - provided

--- a/tests/cypress/config/verify_YAML_stability/LimitRange_template-verify.yaml
+++ b/tests/cypress/config/verify_YAML_stability/LimitRange_template-verify.yaml
@@ -13,33 +13,32 @@ metadata:
     - apiVersion: policy.open-cluster-management.io/v1
       fieldsType: FieldsV1
       fieldsV1:
-        'f:metadata':
-          'f:annotations':
+        f:metadata:
+          f:annotations:
             .: {}
-            'f:policy.open-cluster-management.io/categories': {}
-            'f:policy.open-cluster-management.io/controls': {}
-            'f:policy.open-cluster-management.io/standards': {}
-        'f:spec':
+            f:policy.open-cluster-management.io/categories: {}
+            f:policy.open-cluster-management.io/controls: {}
+            f:policy.open-cluster-management.io/standards: {}
+        f:spec:
           .: {}
-          'f:disabled': {}
-          'f:policy-templates': {}
-          'f:remediationAction': {}
+          f:disabled: {}
+          f:policy-templates: {}
+          f:remediationAction: {}
       manager: unknown
       operation: Update
       time: '2021-01-22T16:36:36Z'
     - apiVersion: policy.open-cluster-management.io/v1
       fieldsType: FieldsV1
       fieldsV1:
-        'f:status':
+        f:status:
           .: {}
-          'f:placement': {}
-          'f:status': {}
+          f:placement: {}
+          f:status: {}
       manager: governance-policy-propagator
       operation: Update
       time: '2021-01-22T16:36:55Z'
   resourceVersion: '193480'
-  selfLink: >-
-    /apis/policy.open-cluster-management.io/v1/namespaces/default/policies/policy-limitrange-[ID]
+  selfLink: /apis/policy.open-cluster-management.io/v1/namespaces/default/policies/policy-limitrange-[ID]
   uid: 0c0cd92c-c98b-4a05-9155-9ebd1ea8aa4e
 spec:
   disabled: false

--- a/tests/jest/containers/__snapshots__/AcmGrcPage.test.js.snap
+++ b/tests/jest/containers/__snapshots__/AcmGrcPage.test.js.snap
@@ -46202,43 +46202,43 @@ metadata:
     - apiVersion: policy.open-cluster-management.io/v1
       fieldsType: FieldsV1
       fieldsV1:
-        'f:metadata':
-          'f:labels':
+        f:metadata:
+          f:labels:
             .: {}
-            'f:cluster-name': {}
-            'f:cluster-namespace': {}
-            'f:policy.open-cluster-management.io/cluster-name': {}
-            'f:policy.open-cluster-management.io/cluster-namespace': {}
-          'f:ownerReferences':
+            f:cluster-name: {}
+            f:cluster-namespace: {}
+            f:policy.open-cluster-management.io/cluster-name: {}
+            f:policy.open-cluster-management.io/cluster-namespace: {}
+          f:ownerReferences:
             .: {}
-            'k:{\\"uid\\":\\"cc918967-492a-4b67-91c4-16a1b19d0c33\\"}':
+            k:{\\"uid\\":\\"cc918967-492a-4b67-91c4-16a1b19d0c33\\"}:
               .: {}
-              'f:apiVersion': {}
-              'f:blockOwnerDeletion': {}
-              'f:controller': {}
-              'f:kind': {}
-              'f:name': {}
-              'f:uid': {}
-        'f:spec':
+              f:apiVersion: {}
+              f:blockOwnerDeletion: {}
+              f:controller: {}
+              f:kind: {}
+              f:name: {}
+              f:uid: {}
+        f:spec:
           .: {}
-          'f:namespaceSelector':
+          f:namespaceSelector:
             .: {}
-            'f:exclude': {}
-            'f:include': {}
-          'f:object-templates': {}
-          'f:remediationAction': {}
-          'f:severity': {}
+            f:exclude: {}
+            f:include: {}
+          f:object-templates: {}
+          f:remediationAction: {}
+          f:severity: {}
       manager: governance-policy-template-sync
       operation: Update
       time: '2021-04-08T23:33:17Z'
     - apiVersion: policy.open-cluster-management.io/v1
       fieldsType: FieldsV1
       fieldsV1:
-        'f:status':
+        f:status:
           .: {}
-          'f:compliancyDetails': {}
-          'f:compliant': {}
-          'f:relatedObjects': {}
+          f:compliancyDetails: {}
+          f:compliant: {}
+          f:relatedObjects: {}
       manager: config-policy-controller
       operation: Update
       time: '2021-04-08T23:33:32Z'
@@ -46252,8 +46252,7 @@ metadata:
       name: default.policy-pod
       uid: cc918967-492a-4b67-91c4-16a1b19d0c33
   resourceVersion: '11119715'
-  selfLink: >-
-    /apis/policy.open-cluster-management.io/v1/namespaces/local-cluster/configurationpolicies/policy-pod-nginx-pod
+  selfLink: /apis/policy.open-cluster-management.io/v1/namespaces/local-cluster/configurationpolicies/policy-pod-nginx-pod
   uid: 45ca9249-6b0b-4522-bcce-271da96dc624
 spec:
   namespaceSelector:
@@ -46270,7 +46269,7 @@ spec:
           name: nginx-pod
         spec:
           containers:
-            - image: 'nginx:1.18.0'
+            - image: nginx:1.18.0
               name: nginx
               ports:
                 - containerPort: 80


### PR DESCRIPTION
Signed-off-by: Yu Cao <ycao@redhat.com>
https://github.com/open-cluster-management/backlog/issues/10417
~~The extra line break is needed for  js-yaml to parse embedded certificate correctly~~
Finally figured out the root cause of extra line break. It was being introduced when dumping the json object to yaml where the lineWidth is 80 by default. Setting it to `-1` (unlimited) to avoid the extra new line
<img width="1983" alt="image" src="https://user-images.githubusercontent.com/16092291/116268741-99397f00-a74b-11eb-883e-59c91a0162b0.png">

The would ensure the policy is creates correct certificate
<img width="1252" alt="image" src="https://user-images.githubusercontent.com/16092291/116155690-6d20ee00-a6b8-11eb-8647-d8dccfb8d7a1.png">

