### PR TITLE
Change expandedText from default 'Show Less' to 'Show Fewer'

### DIFF
--- a/src-web/tableDefinitions/hcm-compliances.js
+++ b/src-web/tableDefinitions/hcm-compliances.js
@@ -409,6 +409,7 @@ export function getDecisionList(policy, locale) {
         <span key={`${status}-status-list`} className={`status-list status-list__${status}`}>
           <LabelGroup
             collapsedText='${remaining} more'
+            expandedText='Show fewer'
             numLabels='5'
           >
             {Array.from(clusterList[status]).map((cluster, index) =>{


### PR DESCRIPTION
We suggesting to the user to show fewer clusters. Since they are
countable, we should use `fewer` instead of `less`.

Signed-off-by: arewm <arewm@users.noreply.github.com>

@dockerymick, am I accurate here? Not sure if you saw the playback. :) 