### PR TITLE
Update title style for template YAML on status page 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17490,6 +17490,11 @@
         "react-is": "^16.13.1"
       }
     },
+    "react-resize-observer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/react-resize-observer/-/react-resize-observer-1.1.1.tgz",
+      "integrity": "sha512-3R+90Hou90Mr3wJYc+unsySC8Pn91V4nmjO32NKvUvjphRUbq9HisyLg7bDyGBE7xlMrrM6Fax7iNQaFdc/FYA=="
+    },
     "react-router": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.2.0.tgz",

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "react-dom": "^16.14.0",
     "react-monaco-editor": "0.36.0",
     "react-redux": "^7.2.4",
+    "react-resize-observer": "^1.1.1",
     "react-router-dom": "^5.2.0",
     "react-split-pane": "^0.1.92",
     "redux": "^4.1.0",

--- a/src-web/components/modules/PolicyTemplateDetailsView.js
+++ b/src-web/components/modules/PolicyTemplateDetailsView.js
@@ -14,6 +14,7 @@ import { LocaleContext } from '../common/LocaleContext'
 import relatedObjectsDef from '../../tableDefinitions/relatedObjectsDef'
 import { transform_new } from '../../tableDefinitions/utils'
 import msgs from '../../nls/platform.properties'
+import ResizeObserver from 'react-resize-observer'
 
 import '../../scss/policy-template-details.scss'
 
@@ -38,13 +39,9 @@ class PolicyTemplateDetailsView extends React.Component {
     if (this.containerRef && this.editor) {
       const rect = this.containerRef.getBoundingClientRect()
       const width = rect.width
-      const height = rect.height - 24 // minus height of title
+      const height = rect.height - 65 // minus height of title / card header
       this.editor.layout({width, height})
     }
-  }
-
-  componentDidMount() {
-    window.addEventListener('resize',  this.layoutEditors.bind(this))
   }
 
   render() {
@@ -98,10 +95,15 @@ class PolicyTemplateDetailsView extends React.Component {
             <AcmExpandableCard title={msgs.get('panel.header.template.yaml', locale)}>
               <YamlEditor
                 width={'100%'}
-                height={'100%'}
+                height={'500px'}
                 readOnly
                 setEditor={this.setEditor}
                 yaml={jsYaml.dump(items, {lineWidth: -1})}
+              />
+              <ResizeObserver
+                onReflow={() => {
+                  this.layoutEditors()
+                }}
               />
             </AcmExpandableCard>
           </div>

--- a/src-web/components/modules/PolicyTemplateDetailsView.js
+++ b/src-web/components/modules/PolicyTemplateDetailsView.js
@@ -9,7 +9,7 @@ import { Title } from '@patternfly/react-core'
 import jsYaml from 'js-yaml'
 import _ from 'lodash'
 import YamlEditor from '../common/YamlEditor'
-import { AcmTable, AcmDescriptionList } from '@open-cluster-management/ui-components'
+import { AcmTable, AcmDescriptionList, AcmExpandableCard } from '@open-cluster-management/ui-components'
 import { LocaleContext } from '../common/LocaleContext'
 import relatedObjectsDef from '../../tableDefinitions/relatedObjectsDef'
 import { transform_new } from '../../tableDefinitions/utils'
@@ -95,15 +95,15 @@ class PolicyTemplateDetailsView extends React.Component {
             />
           </div>
           <div className='yaml' ref={this.setContainerRef}>
-            <Title className='title' headingLevel="h2">{msgs.get('panel.header.template.yaml', locale)}</Title>
-            <div>
+            <AcmExpandableCard title={msgs.get('panel.header.template.yaml', locale)}>
               <YamlEditor
                 width={'100%'}
-                height={'500px'}
+                height={'100%'}
                 readOnly
                 setEditor={this.setEditor}
-                yaml={jsYaml.dump(items, {lineWidth: -1})} />
-            </div>
+                yaml={jsYaml.dump(items, {lineWidth: -1})}
+              />
+            </AcmExpandableCard>
           </div>
         </div>
         <div className='table'>

--- a/src-web/scss/policy-template-details.scss
+++ b/src-web/scss/policy-template-details.scss
@@ -10,8 +10,13 @@
   .details {
     display: flex;
     flex-direction: row;
-    .overview {
+    > div {
       display: flex;
+      > article {
+        width: 100%;
+      }
+    }
+    .overview {
       width: 50%;
       background-color: var(--pf-global--BackgroundColor--100);
       margin-right: .75rem;
@@ -40,7 +45,7 @@
           font-family: codicon;
         }
       }
-      .pf-c-card__expandable-content {
+      > article > .pf-c-card__expandable-content {
         padding: 0px;
       }
     }

--- a/src-web/scss/policy-template-details.scss
+++ b/src-web/scss/policy-template-details.scss
@@ -11,6 +11,7 @@
     display: flex;
     flex-direction: row;
     .overview {
+      display: flex;
       width: 50%;
       background-color: var(--pf-global--BackgroundColor--100);
       margin-right: .75rem;
@@ -38,6 +39,9 @@
         .codicon[class*='codicon-'] {
           font-family: codicon;
         }
+      }
+      .pf-c-card__expandable-content {
+        padding: 0px;
       }
     }
     @media screen and (max-width: 68rem) {

--- a/tests/jest/components/modules/__snapshots__/PolicyTemplateDetailsView.test.js.snap
+++ b/tests/jest/components/modules/__snapshots__/PolicyTemplateDetailsView.test.js.snap
@@ -12,7 +12,7 @@ exports[`PolicyTemplateDetailsView component renders as expected -- no related o
     >
       <article
         className="pf-c-card pf-m-expanded"
-        data-ouia-component-id="OUIA-Generated-Card-4"
+        data-ouia-component-id="OUIA-Generated-Card-7"
         data-ouia-component-type="PF4/Card"
         data-ouia-safe={true}
         id=""
@@ -29,7 +29,7 @@ exports[`PolicyTemplateDetailsView component renders as expected -- no related o
               aria-expanded={true}
               aria-label="Toggle details"
               className="pf-c-button pf-m-plain"
-              data-ouia-component-id="OUIA-Generated-Button-plain-16"
+              data-ouia-component-id="OUIA-Generated-Button-plain-19"
               data-ouia-component-type="PF4/Button"
               data-ouia-safe={true}
               disabled={false}
@@ -231,26 +231,158 @@ exports[`PolicyTemplateDetailsView component renders as expected -- no related o
     <div
       className="yaml"
     >
-      <h2
-        className="pf-c-title pf-m-xl title"
+      <article
+        className="pf-c-card pf-m-expanded"
+        data-ouia-component-id="OUIA-Generated-Card-8"
+        data-ouia-component-type="PF4/Card"
+        data-ouia-safe={true}
+        id=""
       >
-        Template yaml
-      </h2>
-      <div>
         <div
-          className="yamlEditorContainer"
+          className="pf-c-card__header makeStyles-header-2"
+          onClick={[Function]}
         >
           <div
-            className="react-monaco-editor-container"
-            style={
-              Object {
-                "height": "500px",
-                "width": "100%",
-              }
-            }
-          />
+            className="pf-c-card__header-toggle"
+          >
+            <button
+              aria-disabled={false}
+              aria-expanded={true}
+              aria-label="Toggle details"
+              className="pf-c-button pf-m-plain"
+              data-ouia-component-id="OUIA-Generated-Button-plain-20"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe={true}
+              disabled={false}
+              id="toggle-button"
+              onClick={[Function]}
+              role={null}
+              type="button"
+            >
+              <span
+                className="pf-c-card__header-toggle-icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 256 512"
+                  width="1em"
+                >
+                  <path
+                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+          <div
+            className="pf-c-card__title"
+          >
+            Template yaml
+          </div>
         </div>
-      </div>
+        <div
+          className="pf-c-card__expandable-content makeStyles-body-3"
+        >
+          <div
+            className="pf-c-card__body"
+          >
+            <div
+              className="yamlEditorContainer"
+            >
+              <div
+                className="react-monaco-editor-container"
+                style={
+                  Object {
+                    "height": "500px",
+                    "width": "100%",
+                  }
+                }
+              />
+            </div>
+            <div
+              style={
+                Object {
+                  "bottom": 0,
+                  "left": 0,
+                  "overflow": "hidden",
+                  "pointerEvents": "none",
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                  "visibility": "hidden",
+                  "zIndex": -1,
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "bottom": 0,
+                    "left": 0,
+                    "overflow": "hidden",
+                    "pointerEvents": "none",
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                    "visibility": "hidden",
+                    "zIndex": -1,
+                  }
+                }
+              >
+                <div
+                  style={
+                    Object {
+                      "height": 100000,
+                      "left": 0,
+                      "position": "absolute",
+                      "top": 0,
+                      "transition": "0s",
+                      "width": 100000,
+                    }
+                  }
+                />
+              </div>
+              <div
+                style={
+                  Object {
+                    "bottom": 0,
+                    "left": 0,
+                    "overflow": "hidden",
+                    "pointerEvents": "none",
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                    "visibility": "hidden",
+                    "zIndex": -1,
+                  }
+                }
+              >
+                <div
+                  style={
+                    Object {
+                      "height": "200%",
+                      "left": 0,
+                      "position": "absolute",
+                      "top": 0,
+                      "transition": "0s",
+                      "width": "200%",
+                    }
+                  }
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </article>
     </div>
   </div>
   <div
@@ -311,7 +443,7 @@ exports[`PolicyTemplateDetailsView component renders as expected -- relatedObjec
     >
       <article
         className="pf-c-card pf-m-expanded"
-        data-ouia-component-id="OUIA-Generated-Card-3"
+        data-ouia-component-id="OUIA-Generated-Card-5"
         data-ouia-component-type="PF4/Card"
         data-ouia-safe={true}
         id=""
@@ -328,7 +460,7 @@ exports[`PolicyTemplateDetailsView component renders as expected -- relatedObjec
               aria-expanded={true}
               aria-label="Toggle details"
               className="pf-c-button pf-m-plain"
-              data-ouia-component-id="OUIA-Generated-Button-plain-15"
+              data-ouia-component-id="OUIA-Generated-Button-plain-17"
               data-ouia-component-type="PF4/Button"
               data-ouia-safe={true}
               disabled={false}
@@ -530,26 +662,158 @@ exports[`PolicyTemplateDetailsView component renders as expected -- relatedObjec
     <div
       className="yaml"
     >
-      <h2
-        className="pf-c-title pf-m-xl title"
+      <article
+        className="pf-c-card pf-m-expanded"
+        data-ouia-component-id="OUIA-Generated-Card-6"
+        data-ouia-component-type="PF4/Card"
+        data-ouia-safe={true}
+        id=""
       >
-        Template yaml
-      </h2>
-      <div>
         <div
-          className="yamlEditorContainer"
+          className="pf-c-card__header makeStyles-header-2"
+          onClick={[Function]}
         >
           <div
-            className="react-monaco-editor-container"
-            style={
-              Object {
-                "height": "500px",
-                "width": "100%",
-              }
-            }
-          />
+            className="pf-c-card__header-toggle"
+          >
+            <button
+              aria-disabled={false}
+              aria-expanded={true}
+              aria-label="Toggle details"
+              className="pf-c-button pf-m-plain"
+              data-ouia-component-id="OUIA-Generated-Button-plain-18"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe={true}
+              disabled={false}
+              id="toggle-button"
+              onClick={[Function]}
+              role={null}
+              type="button"
+            >
+              <span
+                className="pf-c-card__header-toggle-icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 256 512"
+                  width="1em"
+                >
+                  <path
+                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+          <div
+            className="pf-c-card__title"
+          >
+            Template yaml
+          </div>
         </div>
-      </div>
+        <div
+          className="pf-c-card__expandable-content makeStyles-body-3"
+        >
+          <div
+            className="pf-c-card__body"
+          >
+            <div
+              className="yamlEditorContainer"
+            >
+              <div
+                className="react-monaco-editor-container"
+                style={
+                  Object {
+                    "height": "500px",
+                    "width": "100%",
+                  }
+                }
+              />
+            </div>
+            <div
+              style={
+                Object {
+                  "bottom": 0,
+                  "left": 0,
+                  "overflow": "hidden",
+                  "pointerEvents": "none",
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                  "visibility": "hidden",
+                  "zIndex": -1,
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "bottom": 0,
+                    "left": 0,
+                    "overflow": "hidden",
+                    "pointerEvents": "none",
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                    "visibility": "hidden",
+                    "zIndex": -1,
+                  }
+                }
+              >
+                <div
+                  style={
+                    Object {
+                      "height": 100000,
+                      "left": 0,
+                      "position": "absolute",
+                      "top": 0,
+                      "transition": "0s",
+                      "width": 100000,
+                    }
+                  }
+                />
+              </div>
+              <div
+                style={
+                  Object {
+                    "bottom": 0,
+                    "left": 0,
+                    "overflow": "hidden",
+                    "pointerEvents": "none",
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                    "visibility": "hidden",
+                    "zIndex": -1,
+                  }
+                }
+              >
+                <div
+                  style={
+                    Object {
+                      "height": "200%",
+                      "left": 0,
+                      "position": "absolute",
+                      "top": 0,
+                      "transition": "0s",
+                      "width": "200%",
+                    }
+                  }
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </article>
     </div>
   </div>
   <div
@@ -829,26 +1093,158 @@ exports[`PolicyTemplateDetailsView component renders as expected 1`] = `
     <div
       className="yaml"
     >
-      <h2
-        className="pf-c-title pf-m-xl title"
+      <article
+        className="pf-c-card pf-m-expanded"
+        data-ouia-component-id="OUIA-Generated-Card-2"
+        data-ouia-component-type="PF4/Card"
+        data-ouia-safe={true}
+        id=""
       >
-        Template yaml
-      </h2>
-      <div>
         <div
-          className="yamlEditorContainer"
+          className="pf-c-card__header makeStyles-header-2"
+          onClick={[Function]}
         >
           <div
-            className="react-monaco-editor-container"
-            style={
-              Object {
-                "height": "500px",
-                "width": "100%",
-              }
-            }
-          />
+            className="pf-c-card__header-toggle"
+          >
+            <button
+              aria-disabled={false}
+              aria-expanded={true}
+              aria-label="Toggle details"
+              className="pf-c-button pf-m-plain"
+              data-ouia-component-id="OUIA-Generated-Button-plain-2"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe={true}
+              disabled={false}
+              id="toggle-button"
+              onClick={[Function]}
+              role={null}
+              type="button"
+            >
+              <span
+                className="pf-c-card__header-toggle-icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 256 512"
+                  width="1em"
+                >
+                  <path
+                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+          <div
+            className="pf-c-card__title"
+          >
+            Template yaml
+          </div>
         </div>
-      </div>
+        <div
+          className="pf-c-card__expandable-content makeStyles-body-3"
+        >
+          <div
+            className="pf-c-card__body"
+          >
+            <div
+              className="yamlEditorContainer"
+            >
+              <div
+                className="react-monaco-editor-container"
+                style={
+                  Object {
+                    "height": "500px",
+                    "width": "100%",
+                  }
+                }
+              />
+            </div>
+            <div
+              style={
+                Object {
+                  "bottom": 0,
+                  "left": 0,
+                  "overflow": "hidden",
+                  "pointerEvents": "none",
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                  "visibility": "hidden",
+                  "zIndex": -1,
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "bottom": 0,
+                    "left": 0,
+                    "overflow": "hidden",
+                    "pointerEvents": "none",
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                    "visibility": "hidden",
+                    "zIndex": -1,
+                  }
+                }
+              >
+                <div
+                  style={
+                    Object {
+                      "height": 100000,
+                      "left": 0,
+                      "position": "absolute",
+                      "top": 0,
+                      "transition": "0s",
+                      "width": 100000,
+                    }
+                  }
+                />
+              </div>
+              <div
+                style={
+                  Object {
+                    "bottom": 0,
+                    "left": 0,
+                    "overflow": "hidden",
+                    "pointerEvents": "none",
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                    "visibility": "hidden",
+                    "zIndex": -1,
+                  }
+                }
+              >
+                <div
+                  style={
+                    Object {
+                      "height": "200%",
+                      "left": 0,
+                      "position": "absolute",
+                      "top": 0,
+                      "transition": "0s",
+                      "width": "200%",
+                    }
+                  }
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </article>
     </div>
   </div>
   <div
@@ -1032,7 +1428,7 @@ exports[`PolicyTemplateDetailsView component renders as expected 1`] = `
                     aria-label="Go to previous page"
                     className="pf-c-button pf-m-plain pf-m-disabled"
                     data-action="previous"
-                    data-ouia-component-id="OUIA-Generated-Button-plain-2"
+                    data-ouia-component-id="OUIA-Generated-Button-plain-3"
                     data-ouia-component-type="PF4/Button"
                     data-ouia-safe={true}
                     disabled={true}
@@ -1069,7 +1465,7 @@ exports[`PolicyTemplateDetailsView component renders as expected 1`] = `
                     aria-label="Go to next page"
                     className="pf-c-button pf-m-plain pf-m-disabled"
                     data-action="next"
-                    data-ouia-component-id="OUIA-Generated-Button-plain-3"
+                    data-ouia-component-id="OUIA-Generated-Button-plain-4"
                     data-ouia-component-type="PF4/Button"
                     data-ouia-safe={true}
                     disabled={true}
@@ -2057,7 +2453,7 @@ exports[`PolicyTemplateDetailsView component renders as expected 1`] = `
             aria-label="Go to first page"
             className="pf-c-button pf-m-plain pf-m-disabled"
             data-action="first"
-            data-ouia-component-id="OUIA-Generated-Button-plain-4"
+            data-ouia-component-id="OUIA-Generated-Button-plain-5"
             data-ouia-component-type="PF4/Button"
             data-ouia-safe={true}
             disabled={true}
@@ -2094,7 +2490,7 @@ exports[`PolicyTemplateDetailsView component renders as expected 1`] = `
             aria-label="Go to previous page"
             className="pf-c-button pf-m-plain pf-m-disabled"
             data-action="previous"
-            data-ouia-component-id="OUIA-Generated-Button-plain-5"
+            data-ouia-component-id="OUIA-Generated-Button-plain-6"
             data-ouia-component-type="PF4/Button"
             data-ouia-safe={true}
             disabled={true}
@@ -2153,7 +2549,7 @@ exports[`PolicyTemplateDetailsView component renders as expected 1`] = `
             aria-label="Go to next page"
             className="pf-c-button pf-m-plain pf-m-disabled"
             data-action="next"
-            data-ouia-component-id="OUIA-Generated-Button-plain-6"
+            data-ouia-component-id="OUIA-Generated-Button-plain-7"
             data-ouia-component-type="PF4/Button"
             data-ouia-safe={true}
             disabled={true}
@@ -2190,7 +2586,7 @@ exports[`PolicyTemplateDetailsView component renders as expected 1`] = `
             aria-label="Go to last page"
             className="pf-c-button pf-m-plain pf-m-disabled"
             data-action="last"
-            data-ouia-component-id="OUIA-Generated-Button-plain-7"
+            data-ouia-component-id="OUIA-Generated-Button-plain-8"
             data-ouia-component-type="PF4/Button"
             data-ouia-safe={true}
             disabled={true}
@@ -2237,7 +2633,7 @@ exports[`PolicyTemplateDetailsView component renders as expected with SelfLinnk 
     >
       <article
         className="pf-c-card pf-m-expanded"
-        data-ouia-component-id="OUIA-Generated-Card-2"
+        data-ouia-component-id="OUIA-Generated-Card-3"
         data-ouia-component-type="PF4/Card"
         data-ouia-safe={true}
         id=""
@@ -2254,7 +2650,7 @@ exports[`PolicyTemplateDetailsView component renders as expected with SelfLinnk 
               aria-expanded={true}
               aria-label="Toggle details"
               className="pf-c-button pf-m-plain"
-              data-ouia-component-id="OUIA-Generated-Button-plain-8"
+              data-ouia-component-id="OUIA-Generated-Button-plain-9"
               data-ouia-component-type="PF4/Button"
               data-ouia-safe={true}
               disabled={false}
@@ -2456,26 +2852,158 @@ exports[`PolicyTemplateDetailsView component renders as expected with SelfLinnk 
     <div
       className="yaml"
     >
-      <h2
-        className="pf-c-title pf-m-xl title"
+      <article
+        className="pf-c-card pf-m-expanded"
+        data-ouia-component-id="OUIA-Generated-Card-4"
+        data-ouia-component-type="PF4/Card"
+        data-ouia-safe={true}
+        id=""
       >
-        Template yaml
-      </h2>
-      <div>
         <div
-          className="yamlEditorContainer"
+          className="pf-c-card__header makeStyles-header-2"
+          onClick={[Function]}
         >
           <div
-            className="react-monaco-editor-container"
-            style={
-              Object {
-                "height": "500px",
-                "width": "100%",
-              }
-            }
-          />
+            className="pf-c-card__header-toggle"
+          >
+            <button
+              aria-disabled={false}
+              aria-expanded={true}
+              aria-label="Toggle details"
+              className="pf-c-button pf-m-plain"
+              data-ouia-component-id="OUIA-Generated-Button-plain-10"
+              data-ouia-component-type="PF4/Button"
+              data-ouia-safe={true}
+              disabled={false}
+              id="toggle-button"
+              onClick={[Function]}
+              role={null}
+              type="button"
+            >
+              <span
+                className="pf-c-card__header-toggle-icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  aria-labelledby={null}
+                  fill="currentColor"
+                  height="1em"
+                  role="img"
+                  style={
+                    Object {
+                      "verticalAlign": "-0.125em",
+                    }
+                  }
+                  viewBox="0 0 256 512"
+                  width="1em"
+                >
+                  <path
+                    d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                  />
+                </svg>
+              </span>
+            </button>
+          </div>
+          <div
+            className="pf-c-card__title"
+          >
+            Template yaml
+          </div>
         </div>
-      </div>
+        <div
+          className="pf-c-card__expandable-content makeStyles-body-3"
+        >
+          <div
+            className="pf-c-card__body"
+          >
+            <div
+              className="yamlEditorContainer"
+            >
+              <div
+                className="react-monaco-editor-container"
+                style={
+                  Object {
+                    "height": "500px",
+                    "width": "100%",
+                  }
+                }
+              />
+            </div>
+            <div
+              style={
+                Object {
+                  "bottom": 0,
+                  "left": 0,
+                  "overflow": "hidden",
+                  "pointerEvents": "none",
+                  "position": "absolute",
+                  "right": 0,
+                  "top": 0,
+                  "visibility": "hidden",
+                  "zIndex": -1,
+                }
+              }
+            >
+              <div
+                style={
+                  Object {
+                    "bottom": 0,
+                    "left": 0,
+                    "overflow": "hidden",
+                    "pointerEvents": "none",
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                    "visibility": "hidden",
+                    "zIndex": -1,
+                  }
+                }
+              >
+                <div
+                  style={
+                    Object {
+                      "height": 100000,
+                      "left": 0,
+                      "position": "absolute",
+                      "top": 0,
+                      "transition": "0s",
+                      "width": 100000,
+                    }
+                  }
+                />
+              </div>
+              <div
+                style={
+                  Object {
+                    "bottom": 0,
+                    "left": 0,
+                    "overflow": "hidden",
+                    "pointerEvents": "none",
+                    "position": "absolute",
+                    "right": 0,
+                    "top": 0,
+                    "visibility": "hidden",
+                    "zIndex": -1,
+                  }
+                }
+              >
+                <div
+                  style={
+                    Object {
+                      "height": "200%",
+                      "left": 0,
+                      "position": "absolute",
+                      "top": 0,
+                      "transition": "0s",
+                      "width": "200%",
+                    }
+                  }
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      </article>
     </div>
   </div>
   <div
@@ -2659,7 +3187,7 @@ exports[`PolicyTemplateDetailsView component renders as expected with SelfLinnk 
                     aria-label="Go to previous page"
                     className="pf-c-button pf-m-plain pf-m-disabled"
                     data-action="previous"
-                    data-ouia-component-id="OUIA-Generated-Button-plain-9"
+                    data-ouia-component-id="OUIA-Generated-Button-plain-11"
                     data-ouia-component-type="PF4/Button"
                     data-ouia-safe={true}
                     disabled={true}
@@ -2696,7 +3224,7 @@ exports[`PolicyTemplateDetailsView component renders as expected with SelfLinnk 
                     aria-label="Go to next page"
                     className="pf-c-button pf-m-plain pf-m-disabled"
                     data-action="next"
-                    data-ouia-component-id="OUIA-Generated-Button-plain-10"
+                    data-ouia-component-id="OUIA-Generated-Button-plain-12"
                     data-ouia-component-type="PF4/Button"
                     data-ouia-safe={true}
                     disabled={true}
@@ -3684,7 +4212,7 @@ exports[`PolicyTemplateDetailsView component renders as expected with SelfLinnk 
             aria-label="Go to first page"
             className="pf-c-button pf-m-plain pf-m-disabled"
             data-action="first"
-            data-ouia-component-id="OUIA-Generated-Button-plain-11"
+            data-ouia-component-id="OUIA-Generated-Button-plain-13"
             data-ouia-component-type="PF4/Button"
             data-ouia-safe={true}
             disabled={true}
@@ -3721,7 +4249,7 @@ exports[`PolicyTemplateDetailsView component renders as expected with SelfLinnk 
             aria-label="Go to previous page"
             className="pf-c-button pf-m-plain pf-m-disabled"
             data-action="previous"
-            data-ouia-component-id="OUIA-Generated-Button-plain-12"
+            data-ouia-component-id="OUIA-Generated-Button-plain-14"
             data-ouia-component-type="PF4/Button"
             data-ouia-safe={true}
             disabled={true}
@@ -3780,7 +4308,7 @@ exports[`PolicyTemplateDetailsView component renders as expected with SelfLinnk 
             aria-label="Go to next page"
             className="pf-c-button pf-m-plain pf-m-disabled"
             data-action="next"
-            data-ouia-component-id="OUIA-Generated-Button-plain-13"
+            data-ouia-component-id="OUIA-Generated-Button-plain-15"
             data-ouia-component-type="PF4/Button"
             data-ouia-safe={true}
             disabled={true}
@@ -3817,7 +4345,7 @@ exports[`PolicyTemplateDetailsView component renders as expected with SelfLinnk 
             aria-label="Go to last page"
             className="pf-c-button pf-m-plain pf-m-disabled"
             data-action="last"
-            data-ouia-component-id="OUIA-Generated-Button-plain-14"
+            data-ouia-component-id="OUIA-Generated-Button-plain-16"
             data-ouia-component-type="PF4/Button"
             data-ouia-safe={true}
             disabled={true}

--- a/tests/jest/containers/__snapshots__/AcmGrcPage.test.js.snap
+++ b/tests/jest/containers/__snapshots__/AcmGrcPage.test.js.snap
@@ -38393,7 +38393,7 @@ exports[`AcmGrcPage container should render POLICY_STATUS_HISTORY page  1`] = `
                                                                       aria-label="Go to previous page"
                                                                       className="pf-c-button pf-m-plain pf-m-disabled"
                                                                       data-action="previous"
-                                                                      data-ouia-component-id="OUIA-Generated-Button-plain-18"
+                                                                      data-ouia-component-id="OUIA-Generated-Button-plain-19"
                                                                       data-ouia-component-type="PF4/Button"
                                                                       data-ouia-safe={true}
                                                                       disabled={true}
@@ -38444,7 +38444,7 @@ exports[`AcmGrcPage container should render POLICY_STATUS_HISTORY page  1`] = `
                                                                       aria-label="Go to next page"
                                                                       className="pf-c-button pf-m-plain pf-m-disabled"
                                                                       data-action="next"
-                                                                      data-ouia-component-id="OUIA-Generated-Button-plain-19"
+                                                                      data-ouia-component-id="OUIA-Generated-Button-plain-20"
                                                                       data-ouia-component-type="PF4/Button"
                                                                       data-ouia-safe={true}
                                                                       disabled={true}
@@ -41923,7 +41923,7 @@ exports[`AcmGrcPage container should render POLICY_STATUS_HISTORY page  1`] = `
                                                       aria-label="Go to first page"
                                                       className="pf-c-button pf-m-plain pf-m-disabled"
                                                       data-action="first"
-                                                      data-ouia-component-id="OUIA-Generated-Button-plain-20"
+                                                      data-ouia-component-id="OUIA-Generated-Button-plain-21"
                                                       data-ouia-component-type="PF4/Button"
                                                       data-ouia-safe={true}
                                                       disabled={true}
@@ -41974,7 +41974,7 @@ exports[`AcmGrcPage container should render POLICY_STATUS_HISTORY page  1`] = `
                                                       aria-label="Go to previous page"
                                                       className="pf-c-button pf-m-plain pf-m-disabled"
                                                       data-action="previous"
-                                                      data-ouia-component-id="OUIA-Generated-Button-plain-21"
+                                                      data-ouia-component-id="OUIA-Generated-Button-plain-22"
                                                       data-ouia-component-type="PF4/Button"
                                                       data-ouia-safe={true}
                                                       disabled={true}
@@ -42047,7 +42047,7 @@ exports[`AcmGrcPage container should render POLICY_STATUS_HISTORY page  1`] = `
                                                       aria-label="Go to next page"
                                                       className="pf-c-button pf-m-plain pf-m-disabled"
                                                       data-action="next"
-                                                      data-ouia-component-id="OUIA-Generated-Button-plain-22"
+                                                      data-ouia-component-id="OUIA-Generated-Button-plain-23"
                                                       data-ouia-component-type="PF4/Button"
                                                       data-ouia-safe={true}
                                                       disabled={true}
@@ -42098,7 +42098,7 @@ exports[`AcmGrcPage container should render POLICY_STATUS_HISTORY page  1`] = `
                                                       aria-label="Go to last page"
                                                       className="pf-c-button pf-m-plain pf-m-disabled"
                                                       data-action="last"
-                                                      data-ouia-component-id="OUIA-Generated-Button-plain-23"
+                                                      data-ouia-component-id="OUIA-Generated-Button-plain-24"
                                                       data-ouia-component-type="PF4/Button"
                                                       data-ouia-safe={true}
                                                       disabled={true}
@@ -49917,23 +49917,117 @@ exports[`AcmGrcPage container should render POLICY_TEMPLATE_DETAILS page  1`] = 
                                       <div
                                         className="yaml"
                                       >
-                                        <Title
-                                          className="title"
-                                          headingLevel="h2"
+                                        <AcmExpandableCard
+                                          title="Template yaml"
                                         >
-                                          <h2
-                                            className="pf-c-title pf-m-xl title"
+                                          <Card
+                                            isExpanded={true}
                                           >
-                                            Template yaml
-                                          </h2>
-                                        </Title>
-                                        <div>
-                                          <mockYamlEditor
-                                            height="500px"
-                                            readOnly={true}
-                                            setEditor={[Function]}
-                                            width="100%"
-                                            yaml="apiVersion: policy.open-cluster-management.io/v1
+                                            <article
+                                              className="pf-c-card pf-m-expanded"
+                                              data-ouia-component-id="OUIA-Generated-Card-2"
+                                              data-ouia-component-type="PF4/Card"
+                                              data-ouia-safe={true}
+                                              id=""
+                                            >
+                                              <CardHeader
+                                                className="makeStyles-header-17"
+                                                onClick={[Function]}
+                                                onExpand={[Function]}
+                                                toggleButtonProps={
+                                                  Object {
+                                                    "aria-expanded": true,
+                                                    "aria-label": "Toggle details",
+                                                    "id": "toggle-button",
+                                                  }
+                                                }
+                                              >
+                                                <div
+                                                  className="pf-c-card__header makeStyles-header-17"
+                                                  onClick={[Function]}
+                                                >
+                                                  <div
+                                                    className="pf-c-card__header-toggle"
+                                                  >
+                                                    <Button
+                                                      aria-expanded={true}
+                                                      aria-label="Toggle details"
+                                                      id="toggle-button"
+                                                      onClick={[Function]}
+                                                      type="button"
+                                                      variant="plain"
+                                                    >
+                                                      <button
+                                                        aria-disabled={false}
+                                                        aria-expanded={true}
+                                                        aria-label="Toggle details"
+                                                        className="pf-c-button pf-m-plain"
+                                                        data-ouia-component-id="OUIA-Generated-Button-plain-12"
+                                                        data-ouia-component-type="PF4/Button"
+                                                        data-ouia-safe={true}
+                                                        disabled={false}
+                                                        id="toggle-button"
+                                                        onClick={[Function]}
+                                                        role={null}
+                                                        type="button"
+                                                      >
+                                                        <span
+                                                          className="pf-c-card__header-toggle-icon"
+                                                        >
+                                                          <AngleRightIcon
+                                                            aria-hidden="true"
+                                                            color="currentColor"
+                                                            noVerticalAlign={false}
+                                                            size="sm"
+                                                          >
+                                                            <svg
+                                                              aria-hidden="true"
+                                                              aria-labelledby={null}
+                                                              fill="currentColor"
+                                                              height="1em"
+                                                              role="img"
+                                                              style={
+                                                                Object {
+                                                                  "verticalAlign": "-0.125em",
+                                                                }
+                                                              }
+                                                              viewBox="0 0 256 512"
+                                                              width="1em"
+                                                            >
+                                                              <path
+                                                                d="M224.3 273l-136 136c-9.4 9.4-24.6 9.4-33.9 0l-22.6-22.6c-9.4-9.4-9.4-24.6 0-33.9l96.4-96.4-96.4-96.4c-9.4-9.4-9.4-24.6 0-33.9L54.3 103c9.4-9.4 24.6-9.4 33.9 0l136 136c9.5 9.4 9.5 24.6.1 34z"
+                                                              />
+                                                            </svg>
+                                                          </AngleRightIcon>
+                                                        </span>
+                                                      </button>
+                                                    </Button>
+                                                  </div>
+                                                  <CardTitle>
+                                                    <div
+                                                      className="pf-c-card__title"
+                                                    >
+                                                      Template yaml
+                                                    </div>
+                                                  </CardTitle>
+                                                </div>
+                                              </CardHeader>
+                                              <CardExpandableContent
+                                                className="makeStyles-body-18"
+                                              >
+                                                <div
+                                                  className="pf-c-card__expandable-content makeStyles-body-18"
+                                                >
+                                                  <CardBody>
+                                                    <div
+                                                      className="pf-c-card__body"
+                                                    >
+                                                      <mockYamlEditor
+                                                        height="500px"
+                                                        readOnly={true}
+                                                        setEditor={[Function]}
+                                                        width="100%"
+                                                        yaml="apiVersion: policy.open-cluster-management.io/v1
 kind: ConfigurationPolicy
 metadata:
   creationTimestamp: '2021-04-08T23:33:17Z'
@@ -50041,12 +50135,94 @@ status:
           namespace: default
       reason: Resource not found but should exist
 "
-                                          >
-                                            <div
-                                              data-testid="mockYamlEditor"
-                                            />
-                                          </mockYamlEditor>
-                                        </div>
+                                                      >
+                                                        <div
+                                                          data-testid="mockYamlEditor"
+                                                        />
+                                                      </mockYamlEditor>
+                                                      <ResizeObserver
+                                                        onReflow={[Function]}
+                                                      >
+                                                        <div
+                                                          style={
+                                                            Object {
+                                                              "bottom": 0,
+                                                              "left": 0,
+                                                              "overflow": "hidden",
+                                                              "pointerEvents": "none",
+                                                              "position": "absolute",
+                                                              "right": 0,
+                                                              "top": 0,
+                                                              "visibility": "hidden",
+                                                              "zIndex": -1,
+                                                            }
+                                                          }
+                                                        >
+                                                          <div
+                                                            style={
+                                                              Object {
+                                                                "bottom": 0,
+                                                                "left": 0,
+                                                                "overflow": "hidden",
+                                                                "pointerEvents": "none",
+                                                                "position": "absolute",
+                                                                "right": 0,
+                                                                "top": 0,
+                                                                "visibility": "hidden",
+                                                                "zIndex": -1,
+                                                              }
+                                                            }
+                                                          >
+                                                            <div
+                                                              style={
+                                                                Object {
+                                                                  "height": 100000,
+                                                                  "left": 0,
+                                                                  "position": "absolute",
+                                                                  "top": 0,
+                                                                  "transition": "0s",
+                                                                  "width": 100000,
+                                                                }
+                                                              }
+                                                            />
+                                                          </div>
+                                                          <div
+                                                            style={
+                                                              Object {
+                                                                "bottom": 0,
+                                                                "left": 0,
+                                                                "overflow": "hidden",
+                                                                "pointerEvents": "none",
+                                                                "position": "absolute",
+                                                                "right": 0,
+                                                                "top": 0,
+                                                                "visibility": "hidden",
+                                                                "zIndex": -1,
+                                                              }
+                                                            }
+                                                          >
+                                                            <div
+                                                              style={
+                                                                Object {
+                                                                  "height": "200%",
+                                                                  "left": 0,
+                                                                  "position": "absolute",
+                                                                  "top": 0,
+                                                                  "transition": "0s",
+                                                                  "width": "200%",
+                                                                }
+                                                              }
+                                                            />
+                                                          </div>
+                                                        </div>
+                                                      </ResizeObserver>
+                                                    </div>
+                                                  </CardBody>
+                                                </div>
+                                              </CardExpandableContent>
+                                            </article>
+                                          </Card>
+                                        </AcmExpandableCard>
                                       </div>
                                     </div>
                                     <div
@@ -50865,7 +51041,7 @@ status:
                                                                       aria-label="Go to previous page"
                                                                       className="pf-c-button pf-m-plain pf-m-disabled"
                                                                       data-action="previous"
-                                                                      data-ouia-component-id="OUIA-Generated-Button-plain-12"
+                                                                      data-ouia-component-id="OUIA-Generated-Button-plain-13"
                                                                       data-ouia-component-type="PF4/Button"
                                                                       data-ouia-safe={true}
                                                                       disabled={true}
@@ -50916,7 +51092,7 @@ status:
                                                                       aria-label="Go to next page"
                                                                       className="pf-c-button pf-m-plain pf-m-disabled"
                                                                       data-action="next"
-                                                                      data-ouia-component-id="OUIA-Generated-Button-plain-13"
+                                                                      data-ouia-component-id="OUIA-Generated-Button-plain-14"
                                                                       data-ouia-component-type="PF4/Button"
                                                                       data-ouia-safe={true}
                                                                       disabled={true}
@@ -56392,7 +56568,7 @@ status:
                                                       aria-label="Go to first page"
                                                       className="pf-c-button pf-m-plain pf-m-disabled"
                                                       data-action="first"
-                                                      data-ouia-component-id="OUIA-Generated-Button-plain-14"
+                                                      data-ouia-component-id="OUIA-Generated-Button-plain-15"
                                                       data-ouia-component-type="PF4/Button"
                                                       data-ouia-safe={true}
                                                       disabled={true}
@@ -56443,7 +56619,7 @@ status:
                                                       aria-label="Go to previous page"
                                                       className="pf-c-button pf-m-plain pf-m-disabled"
                                                       data-action="previous"
-                                                      data-ouia-component-id="OUIA-Generated-Button-plain-15"
+                                                      data-ouia-component-id="OUIA-Generated-Button-plain-16"
                                                       data-ouia-component-type="PF4/Button"
                                                       data-ouia-safe={true}
                                                       disabled={true}
@@ -56516,7 +56692,7 @@ status:
                                                       aria-label="Go to next page"
                                                       className="pf-c-button pf-m-plain pf-m-disabled"
                                                       data-action="next"
-                                                      data-ouia-component-id="OUIA-Generated-Button-plain-16"
+                                                      data-ouia-component-id="OUIA-Generated-Button-plain-17"
                                                       data-ouia-component-type="PF4/Button"
                                                       data-ouia-safe={true}
                                                       disabled={true}
@@ -56567,7 +56743,7 @@ status:
                                                       aria-label="Go to last page"
                                                       className="pf-c-button pf-m-plain pf-m-disabled"
                                                       data-action="last"
-                                                      data-ouia-component-id="OUIA-Generated-Button-plain-17"
+                                                      data-ouia-component-id="OUIA-Generated-Button-plain-18"
                                                       data-ouia-component-type="PF4/Button"
                                                       data-ouia-safe={true}
                                                       disabled={true}


### PR DESCRIPTION
The left side was previously updated to be an AcmDescriptionList, which changed the style of its title. This updates the right side (the YAML side) to be in an AcmExpandableCard, which matches the style.

New look: 

![Screen Shot 2021-05-17 at 2 16 01 PM](https://user-images.githubusercontent.com/44813129/118537019-6bc46d80-b71a-11eb-9daf-86bedeb484bf.png)
