### PR TITLE
disallow name/namespace change in edit mode

### DIFF
--- a/src-web/components/common/TemplateEditor/TemplateEditor.js
+++ b/src-web/components/common/TemplateEditor/TemplateEditor.js
@@ -728,18 +728,18 @@ export default class TemplateEditor extends React.Component {
 
     // Parse, validate, and add exception decorations
     const { parsed: newParsed, exceptions } = parseYAML(templateYAML)
-    validateYAML(newParsed, controlData, exceptions, locale)
-    this.handleExceptions(exceptions)
-    if (isEdit) {
+    console.log(exceptions)
+    if (isEdit && exceptions.length === 0) {
       // in edit mode, revert any change to policy/pb/plr name and namespace
       ['Policy', 'PlacementRule', 'PlacementBinding'].forEach(e => {
-        if (newParsed[e][0].$raw.metadata.name !== templateObject[e][0].$raw.metadata.name ||
-            newParsed[e][0].$raw.metadata.namespace !== templateObject[e][0].$raw.metadata.namespace) {
+        if (_.get(newParsed,`${e}[0].$raw.metadata.name`) !== _.get(templateObject,`${e}[0].$raw.metadata.name`) ||
+          _.get(newParsed,`${e}[0].$raw.metadata.namespace`) !== _.get(templateObject,`${e}[0].$raw.metadata.namespace`)) {
           this.editor.trigger('api', 'undo')
-          return
         }
       })
     }
+    validateYAML(newParsed, controlData, exceptions, locale)
+    this.handleExceptions(exceptions)
     // If updateMessage is not empty, then there might be a notification message that we'll need to update
     if (updateMessage) {
       this.handleExceptionNotification(exceptions, 'success.edit.policy.check', locale)

--- a/src-web/components/common/TemplateEditor/TemplateEditor.js
+++ b/src-web/components/common/TemplateEditor/TemplateEditor.js
@@ -323,6 +323,7 @@ export default class TemplateEditor extends React.Component {
             isRequired={mustExist}
             validated={!validPolicyName?ValidatedOptions.error:duplicateName?ValidatedOptions.warning:ValidatedOptions.default}
             type="text"
+            isDisabled={this.props.isEdit}
           />
         </div>
       </React.Fragment>
@@ -376,7 +377,7 @@ export default class TemplateEditor extends React.Component {
     })
   }
   renderSingleSelect(control) {
-    const {locale} = this.props
+    const {locale, isEdit} = this.props
     const {id, name, available, description, isOneSelection, mustExist, active} = control
     const {controlState} = this.state
     return (
@@ -404,6 +405,7 @@ export default class TemplateEditor extends React.Component {
             toggleAriaLabel={id}
             placeholderText={msgs.get('policy.create.namespace.tooltip', locale)}
             isOpen={controlState[id]&&controlState[id].isOpen}
+            isDisabled={isEdit}
           >
             {available.map((option) => (
               <SelectOption isDisabled={false} key={option} value={option} />
@@ -719,15 +721,25 @@ export default class TemplateEditor extends React.Component {
   }
 
   handleParse = () => {
-    const {locale}= this.props
+    const { locale, isEdit }= this.props
     let { isCustomName } = this.state
     const { templateYAML, templateObject, updateMessage } = this.state
     let { controlData } = this.state
 
     // Parse, validate, and add exception decorations
-    const { parsed: newParsed, exceptions} = parseYAML(templateYAML)
+    const { parsed: newParsed, exceptions } = parseYAML(templateYAML)
     validateYAML(newParsed, controlData, exceptions, locale)
     this.handleExceptions(exceptions)
+    if (isEdit) {
+      // in edit mode, revert any change to policy/pb/plr name and namespace
+      ['Policy', 'PlacementRule', 'PlacementBinding'].forEach(e => {
+        if (newParsed[e][0].$raw.metadata.name !== templateObject[e][0].$raw.metadata.name ||
+            newParsed[e][0].$raw.metadata.namespace !== templateObject[e][0].$raw.metadata.namespace) {
+          this.editor.trigger('api', 'undo')
+          return
+        }
+      })
+    }
     // If updateMessage is not empty, then there might be a notification message that we'll need to update
     if (updateMessage) {
       this.handleExceptionNotification(exceptions, 'success.edit.policy.check', locale)

--- a/src-web/components/common/TemplateEditor/TemplateEditor.js
+++ b/src-web/components/common/TemplateEditor/TemplateEditor.js
@@ -728,7 +728,6 @@ export default class TemplateEditor extends React.Component {
 
     // Parse, validate, and add exception decorations
     const { parsed: newParsed, exceptions } = parseYAML(templateYAML)
-    console.log(exceptions)
     if (isEdit && exceptions.length === 0) {
       // in edit mode, revert any change to policy/pb/plr name and namespace
       ['Policy', 'PlacementRule', 'PlacementBinding'].forEach(e => {

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -5,8 +5,8 @@ import { getOpt } from '../scripts/utils'
 import 'cypress-wait-until'
 import { pageLoader, isPolicyStatusAvailable, isClusterTemplateStatusAvailable,
          action_doTableSearch, action_clearTableSearch, action_createPolicyFromSelection, action_verifyPolicyInListing,
-         action_verifyPolicyNotInListing, action_actionPolicyActionInListing, action_createPolicyFromYAML,
-         action_verifyPolicyInPolicyDetails, action_verifyClusterListInPolicyDetails,
+         action_verifyPolicyNotInListing, action_actionPolicyActionInListing, action_editPolicyActionInListing, action_createPolicyFromYAML,
+         action_verifyPolicyInPolicyDetails, action_verifyClusterListInPolicyDetails, action_verifyPolicyEditForm,
          action_verifyViolationsInPolicyStatusClusters, action_verifyViolationsInPolicyStatusTemplates,
          action_verifyPolicyDetailsInCluster, action_verifyPolicyTemplatesInCluster,
          action_verifyPolicyViolationDetailsInCluster, action_verifyPolicyViolationDetailsInHistory,
@@ -290,6 +290,14 @@ Cypress.Commands.add('verifyPolicyNotInListing', (uPolicyName) => {
 
 Cypress.Commands.add('actionPolicyActionInListing', (uName, action, cancel=false) => {
   cy.then(() => action_actionPolicyActionInListing(uName, action, cancel))
+})
+
+Cypress.Commands.add('editPolicyActionInListing', (uName) => {
+  cy.then(() => action_editPolicyActionInListing(uName))
+})
+
+Cypress.Commands.add('verifyPolicyEditForm', (uName, policyConfig) => {
+  cy.then(() => action_verifyPolicyEditForm(uName, policyConfig))
 })
 
 Cypress.Commands.add('createPolicyFromYAML', (policyYAML, create=true) => {

--- a/tests/cypress/support/tests.js
+++ b/tests/cypress/support/tests.js
@@ -279,6 +279,15 @@ export const test_genericPolicyGovernance = (confFilePolicy, confFileViolationsI
     }
   }
 
+  // edit policy
+  for (const policyName in confPolicies) {
+    it(`Edit policy ${policyName}`, () => {
+      cy.visit('/multicloud/policies/all').waitForPageContentLoad()
+        .editPolicyActionInListing(policyName)
+      cy.verifyPolicyEditForm(policyName, confPolicies[policyName])
+    })
+  }
+
   // delete created policies at the end
   for (const policyName in confPolicies) {
     it(`Policy ${policyName} can be deleted in the policy listing`, () => {

--- a/tests/cypress/support/views.js
+++ b/tests/cypress/support/views.js
@@ -475,6 +475,33 @@ export const action_actionPolicyActionInListing = (uName, action, cancel=false) 
     .clearTableSearch()
 }
 
+export const action_editPolicyActionInListing = (uName, action='edit') => {
+  cy.CheckGrcMainPage()
+    .doTableSearch(uName)
+    .get('.grc-view-by-policies-table').within(() => {
+    cy.get('a')
+      .contains(uName)
+      .parents('td')
+      .siblings('td')
+      .last().within(() => {
+        cy.get('button').click()
+      })
+  })
+  .then(() => {
+    cy.get('button').contains(action, { matchCase: false }).click()
+  })
+}
+
+export const action_verifyPolicyEditForm = (uName, policyConfig) => {
+  cy.location('pathname').should('eq', `/multicloud/policies/all/${policyConfig['namespace']}/${uName}/edit`)
+  pageLoader.shouldNotExist()
+  cy.get('.pf-c-page__main-section .pf-c-title').contains('Edit policy')
+  cy.get('input[aria-label="name"]').should('be.disabled')
+  cy.get('button[aria-label="namespace"]').should('be.disabled')
+  cy.get('#cancel').click()
+  cy.location('pathname').should('eq', '/multicloud/policies/all')
+}
+
 // needs to be run at /multicloud/policies/all at ClusterViolations tab
 // optionally, specific violationsCounter value can be provided
 export const isClusterViolationsStatusAvailable = (name, violationsCounter) => {


### PR DESCRIPTION
Signed-off-by: Yu Cao <ycao@redhat.com>
https://github.com/open-cluster-management/backlog/issues/13020
1. disabled `name` and `namespace` control
<img width="1618" alt="image" src="https://user-images.githubusercontent.com/16092291/120656005-38d7e480-c451-11eb-9377-ae9c02512521.png">
2. disallow name/namespace change in yaml editor


https://user-images.githubusercontent.com/16092291/120680013-d3dbb900-c467-11eb-8441-ef9388b07a56.mp4


