### PR TITLE
History timestamp sorting

### DIFF
--- a/src-web/tableDefinitions/statusHistoryDef.js
+++ b/src-web/tableDefinitions/statusHistoryDef.js
@@ -42,7 +42,7 @@ export default {
       msgKey: 'table.header.lastReport',
       label: 'timestamp',
       sortable: true,
-      sortLabel: 'message.rawData',
+      sortLabel: 'timestamp.rawData',
       resourceKey: 'timestamp',
       transforms: [wrappable],
       type: 'timestamp'

--- a/tests/jest/components/modules/__snapshots__/PolicyStatusHistoryView.test.js.snap
+++ b/tests/jest/components/modules/__snapshots__/PolicyStatusHistoryView.test.js.snap
@@ -96,7 +96,7 @@ PolicyStatusHistoryView {
                   "cellTransforms": undefined,
                   "header": "Last Report",
                   "search": undefined,
-                  "sort": "message.rawData",
+                  "sort": "timestamp.rawData",
                   "transforms": Array [
                     [Function],
                   ],
@@ -247,7 +247,7 @@ PolicyStatusHistoryView {
                   "cellTransforms": undefined,
                   "header": "Last Report",
                   "search": undefined,
-                  "sort": "message.rawData",
+                  "sort": "timestamp.rawData",
                   "transforms": Array [
                     [Function],
                   ],
@@ -593,7 +593,7 @@ PolicyStatusHistoryView {
                   "cellTransforms": undefined,
                   "header": "Last Report",
                   "search": undefined,
-                  "sort": "message.rawData",
+                  "sort": "timestamp.rawData",
                   "transforms": Array [
                     [Function],
                   ],


### PR DESCRIPTION
I probably copied the sortLabel into this table definition last time. The table was being sorted based on the message, not the timestamp. The other tables appear to be sorted correctly.