### PR TITLE
Fix Babel warning

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,6 +6,7 @@
     "plugins": [
         "@babel/plugin-transform-runtime",
         ["@babel/plugin-proposal-class-properties", { "loose": true }],
+        ["@babel/plugin-proposal-private-methods", { "loose": true }],
         ["@babel/plugin-transform-spread", { "loose": true }],
         "@babel/plugin-syntax-dynamic-import",
         "@babel/plugin-transform-async-to-generator",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -61,7 +61,10 @@ module.exports = {
             options: {
               cacheDirectory: true,
               presets: ['@babel/preset-env', '@babel/preset-react'],
-              plugins: ['@babel/plugin-proposal-class-properties']
+              plugins: [
+                '@babel/plugin-proposal-class-properties',
+                '@babel/plugin-proposal-private-methods',
+              ]
             },
           },
         ]


### PR DESCRIPTION
Addresses this warning from the logs:
```
Though the "loose" option was set to "false" in your @babel/preset-env config, it will not be used for @babel/plugin-proposal-private-methods since the "loose" mode option was set to "true" for @babel/plugin-proposal-class-properties.
The "loose" option must be the same for @babel/plugin-proposal-class-properties, @babel/plugin-proposal-private-methods and @babel/plugin-proposal-private-property-in-object (when they are enabled): you can silence this warning by explicitly adding
	["@babel/plugin-proposal-private-methods", { "loose": true }]
to the "plugins" section of your Babel config.
```