### PR TITLE
Fix editor overflow issues

### DIFF
--- a/src-web/components/common/TemplateEditor/scss/template-editor.scss
+++ b/src-web/components/common/TemplateEditor/scss/template-editor.scss
@@ -9,12 +9,14 @@
 /* Copyright (c) 2020 Red Hat, Inc. */
 
 .creation-view {
-  display: flex;
-  position: relative;
+  display: unset !important;
+  flex-grow: unset !important;
+  margin-top: 1rem;
 
   .creation-view-split-container {
     width: 100%;
     height: calc(100vh - 200px);
+    margin-top: unset;
 
     &.showEditor {
       .creation-view-controls-container {


### PR DESCRIPTION
It appears that the Monaco editor was taking its height from the parent `div`. Unsetting flex and adjusting the element with the margin seems to fix it.

(Still need to test in Chrome)

Addresses https://github.com/open-cluster-management/backlog/issues/13728#issuecomment-870587825