### PR TITLE
Trim whitespace from name input

### DIFF
--- a/src-web/components/common/TemplateEditor/TemplateEditor.js
+++ b/src-web/components/common/TemplateEditor/TemplateEditor.js
@@ -540,7 +540,7 @@ export default class TemplateEditor extends React.Component {
     const control = controlData.find(({id})=>id===field)
     switch (control.type) {
     case 'text':
-      control.active = evt
+      control.active = evt.trim()
       isCustomName = field==='name'
       break
     case 'singleselect':

--- a/tests/jest/components/common/TemplateEditor/TemplateEditor.test.js
+++ b/tests/jest/components/common/TemplateEditor/TemplateEditor.test.js
@@ -277,19 +277,14 @@ describe('on control change function with active selections', () => {
       />
     )
     const evt = ['selectedItems-testing-1', 'selectedItems-testing-2']
-    expect(wrapper.instance().onChange('name', evt)).toEqual('name')
-    const evt_duplicateName = {
-      target: { value: 'policy-pod' }
-    }
+    const evt_name = 'new_name'
+    expect(wrapper.instance().onChange('name', evt_name)).toEqual('name')
+    const evt_duplicateName = 'policy-pod'
     expect(wrapper.instance().onChange('name', evt_duplicateName)).toEqual('name')
     expect(wrapper.instance().state.duplicateName).toEqual(false)
-    const evt_emptyName = {
-      target: { value: '' }
-    }
+    const evt_emptyName = ''
     expect(wrapper.instance().onChange('name', evt_emptyName)).toEqual('name')
-    const evt_badName = {
-      target: { value: 'a-b-' }
-    }
+    const evt_badName = 'a-b-'
     expect(wrapper.instance().onChange('name', evt_badName)).toEqual('name')
     expect(wrapper.instance().state.duplicateName).toEqual(false)
     expect(wrapper.instance().state.validPolicyName).toEqual(false)
@@ -323,20 +318,14 @@ describe('on control change function without active selections', () => {
       />
     )
     const evt = ['selectedItems-testing-1', 'selectedItems-testing-2']
-
-    expect(wrapper.instance().onChange('name', evt)).toEqual('name')
-    const evt_duplicateName = {
-      target: { value: 'policy-pod' }
-    }
+    const evt_name = 'new_name'
+    expect(wrapper.instance().onChange('name', evt_name)).toEqual('name')
+    const evt_duplicateName = 'policy-pod'
     expect(wrapper.instance().onChange('name', evt_duplicateName)).toEqual('name')
     expect(wrapper.instance().state.duplicateName).toEqual(false)
-    const evt_emptyName = {
-      target: { value: '' }
-    }
+    const evt_emptyName =''
     expect(wrapper.instance().onChange('name', evt_emptyName)).toEqual('name')
-    const evt_badName = {
-      target: { value: 'a-b-' }
-    }
+    const evt_badName = 'a-b-'
     const evt_namespace = {
       selectedItem: 'test-namespace'
     }


### PR DESCRIPTION
This also makes it impossible to add starting or ending whitespace to the name field at all, which I don't think is a bad side effect.

![name-validation](https://user-images.githubusercontent.com/19750917/124032487-9f0b4500-d9c6-11eb-8e01-8c68b969e9c5.gif)

Addresses https://github.com/open-cluster-management/backlog/issues/13620