### PR TITLE
Recalculate table timestamps every 30s

### DIFF
--- a/src-web/components/common/TableTimestamp.js
+++ b/src-web/components/common/TableTimestamp.js
@@ -9,13 +9,27 @@ import PropTypes from 'prop-types'
 import moment from 'moment'
 
 class TableTimestamp extends React.Component {
+  constructor (props) {
+    super(props)
+    this.state = {
+      now: Date.now()
+    }
+  }
+  componentDidMount() {
+    // refresh the timestamp calculation every 30 seconds
+    this.interval = setInterval(() => this.setState({ now: Date.now()}), 30000)
+  }
+  componentWillUnmount() {
+    clearInterval(this.interval)
+  }
   render() {
     const { timestamp } = this.props
+    const { now } = this.state
     let fromNow = 'unknown'
     if (timestamp && timestamp.includes('T')) {
-      fromNow = moment(timestamp, 'YYYY-MM-DDTHH:mm:ssZ').fromNow()
+      fromNow = moment(timestamp, 'YYYY-MM-DDTHH:mm:ssZ').from(now)
     } else if (timestamp) {
-      fromNow = moment(timestamp, 'YYYY-MM-DD HH:mm:ss').fromNow()
+      fromNow = moment(timestamp, 'YYYY-MM-DD HH:mm:ss').from(now)
     }
     return <span>{fromNow}</span>
   }


### PR DESCRIPTION
Currently, the timestamp message (eg "5 minutes ago") is only calculated
when data in the table changes. If the table is open for a while and no
data changes, the message could be out of date.

Refs:
 - https://github.com/open-cluster-management/backlog/issues/13938

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>