### PR TITLE
Update E2E tests

### DIFF
--- a/src-web/components/common/AutomationButton.js
+++ b/src-web/components/common/AutomationButton.js
@@ -101,14 +101,12 @@ class AutomationButton extends React.Component {
       CREATE: false,
       EDIT: false
     }
-    if(Array.isArray(access) && access.length > 0) {
-      const accessObj = access.filter(role => role.namespace === ns)
-      if (accessObj.length > 0 && accessObj[0].rules) {
-        // Check for permissions on Policy and PolicyAutomation resources
-        const resources = [ 'policy.open-cluster-management.io/policyautomations' ]
-        automationAccess.CREATE = checkCreateRole(accessObj[0].rules, resources) === 1
-        automationAccess.EDIT = checkEditRole(accessObj[0].rules, resources) === 1
-      }
+    const accessObj = access.filter(role => role.namespace === ns)
+    if (accessObj.length > 0 && accessObj[0].rules) {
+      // Check for permissions on Policy and PolicyAutomation resources
+      const resources = [ 'policy.open-cluster-management.io/policyautomations' ]
+      automationAccess.CREATE = checkCreateRole(accessObj[0].rules, resources) === 1
+      automationAccess.EDIT = checkEditRole(accessObj[0].rules, resources) === 1
     }
     return automationAccess
   }

--- a/src-web/components/common/AutomationButton.js
+++ b/src-web/components/common/AutomationButton.js
@@ -101,12 +101,14 @@ class AutomationButton extends React.Component {
       CREATE: false,
       EDIT: false
     }
-    const accessObj = access.filter(role => role.namespace === ns)
-    if (accessObj.length > 0 && accessObj[0].rules) {
-      // Check for permissions on Policy and PolicyAutomation resources
-      const resources = [ 'policy.open-cluster-management.io/policyautomations' ]
-      automationAccess.CREATE = checkCreateRole(accessObj[0].rules, resources) === 1
-      automationAccess.EDIT = checkEditRole(accessObj[0].rules, resources) === 1
+    if(Array.isArray(access) && access.length > 0) {
+      const accessObj = access.filter(role => role.namespace === ns)
+      if (accessObj.length > 0 && accessObj[0].rules) {
+        // Check for permissions on Policy and PolicyAutomation resources
+        const resources = [ 'policy.open-cluster-management.io/policyautomations' ]
+        automationAccess.CREATE = checkCreateRole(accessObj[0].rules, resources) === 1
+        automationAccess.EDIT = checkEditRole(accessObj[0].rules, resources) === 1
+      }
     }
     return automationAccess
   }

--- a/tests/cypress/config/automation/clean_up.yaml
+++ b/tests/cypress/config/automation/clean_up.yaml
@@ -75,6 +75,7 @@ spec:
                   name: grcui-e2e-credential
                   namespace: default
                   labels:
+                    cluster.open-cluster-management.io/credentials: ''
                     cluster.open-cluster-management.io/type: ans
                   annotations:
                     credential-hash: sAMw4uiHEj0mLMRXiPwH1iOafWQ/xKzAjozdWDyBI4o=

--- a/tests/cypress/config/automation/create_credential.yaml
+++ b/tests/cypress/config/automation/create_credential.yaml
@@ -31,6 +31,7 @@ spec:
                   name: grcui-e2e-credential
                   namespace: default
                   labels:
+                    cluster.open-cluster-management.io/credentials: ''
                     cluster.open-cluster-management.io/type: ans
                   annotations:
                     credential-hash: sAMw4uiHEj0mLMRXiPwH1iOafWQ/xKzAjozdWDyBI4o=

--- a/tests/cypress/config/automation/create_subscription.yaml
+++ b/tests/cypress/config/automation/create_subscription.yaml
@@ -8,7 +8,7 @@ metadata:
     policy.open-cluster-management.io/categories: PR.IP Information Protection Processes and Procedures
     policy.open-cluster-management.io/controls: PR.IP-1 Baseline Configuration
 spec:
-  remediationAction: enforce
+  remediationAction: inform
   disabled: false
   policy-templates:
     - objectDefinition:

--- a/tests/cypress/support/views.js
+++ b/tests/cypress/support/views.js
@@ -1508,21 +1508,28 @@ export const action_scheduleAutomation = (uName, credentialName, mode) => {
   //mock call to graphQL to get job templates to avoid needing to use a real tower
   cy.intercept('POST', Cypress.config().baseUrl + '/multicloud/policies/graphql', (req) => {
     if (req.body.operationName === 'getAnsibleJobTemplates') {
-        req.reply({
-          data: {
-            ansibleJobTemplates: [
-              {
-                name: demoTemplateName,
-                description: 'hello world ansible job template',
-                extra_vars: 'target_clusters:\n  - local-cluster'
-              }
-            ]
-          }
-        })
+      req.reply({
+        data: {
+          ansibleJobTemplates: [
+            {
+              name: demoTemplateName,
+              description: 'hello world ansible job template',
+              extra_vars: 'target_clusters:\n  - local-cluster'
+            }
+          ]
+        }
+      })
     }
   }).as('templatesQuery')
 
   let failures = 0
+
+  // Check for open Automation modal and close it if it's open
+  if (Cypress.$('#automation-resource-panel').length === 1) {
+    cy.get('#automation-resource-panel').within(() => {
+      cy.get('button[aria-label="Close"]').click()
+    })
+  }
 
   cy.CheckGrcMainPage()
     .doTableSearch(uName)
@@ -1602,6 +1609,12 @@ export const action_scheduleAutomation = (uName, credentialName, mode) => {
 }
 
 export const action_verifyHistoryPageWithMock = (uName) => {
+  // Check for open Automation modal and close it if it's open
+  if (Cypress.$('#automation-resource-panel').length === 1) {
+    cy.get('#automation-resource-panel').within(() => {
+      cy.get('button[aria-label="Close"]').click()
+    })
+  }
   //open modal
   cy.CheckGrcMainPage()
     .doTableSearch(uName)

--- a/tests/cypress/tests/RBAC.spec.js
+++ b/tests/cypress/tests/RBAC.spec.js
@@ -70,7 +70,13 @@ describeT('@rbac RHACM4K-2584 - GRC UI: [P1][Sev1][policy-grc] Role Based Access
   it(`Ansible setup: Check that policy ${subPolicyName} is present in the policy listing`, () => {
     cy.verifyPolicyInListing(subPolicyName, {})
   })
-  it(`Ansible setup: Wait for ${subPolicyName} status to become available`, () => {
+  it(`Ansible setup: Wait for ${subPolicyName} status to become NonCompliant`, () => {
+    cy.waitForPolicyStatus(subPolicyName, '[^0]/')
+  })
+  it(`Ansible setup: Enforce ${subPolicyName}`, () => {
+    cy.actionPolicyActionInListing(subPolicyName, 'Enforce')
+  })
+  it(`Ansible setup: Wait for ${subPolicyName} status to be Compliant`, () => {
     cy.waitForPolicyStatus(subPolicyName, '0/')
   })
   it(`Ansible setup: Delete policy ${subPolicyName}`, () => {

--- a/tests/cypress/tests/ansible_automation.spec.js
+++ b/tests/cypress/tests/ansible_automation.spec.js
@@ -32,7 +32,15 @@ describeT('RHACM4K-3471 - [P1][Sev1][policy-grc] All policies page: Verify autom
     cy.verifyPolicyInListing(subPolicyName, {})
   })
 
-  it(`Wait for ${subPolicyName} status to become available`, () => {
+  it(`Wait for ${subPolicyName} status to become NonCompliant`, () => {
+    cy.waitForPolicyStatus(subPolicyName, '[^0]/')
+  })
+
+  it(`Enforce ${subPolicyName}`, () => {
+    cy.actionPolicyActionInListing(subPolicyName, 'Enforce')
+  })
+
+  it(`Wait for ${subPolicyName} status to be Compliant`, () => {
     cy.waitForPolicyStatus(subPolicyName, '0/')
   })
 

--- a/tests/cypress/tests/ansible_automation.spec.js
+++ b/tests/cypress/tests/ansible_automation.spec.js
@@ -105,17 +105,17 @@ describeT('RHACM4K-3471 - [P1][Sev1][policy-grc] All policies page: Verify autom
 
   //verify contents of modal
   it('Successfully can schedule a disabled automation', {
-    defaultCommandTimeout: 120000
+    defaultCommandTimeout: 180000
   }, () => {
     cy.scheduleAutomation(policyName, 'grcui-e2e-credential', 'disabled')
   })
   it('Successfully can schedule a "run once" automation', {
-    defaultCommandTimeout: 120000
+    defaultCommandTimeout: 180000
   }, () => {
     cy.scheduleAutomation(policyName, 'grcui-e2e-credential', 'once')
   })
   it('Successfully can schedule a "manual" automation', {
-    defaultCommandTimeout: 120000
+    defaultCommandTimeout: 180000
   }, () => {
     cy.scheduleAutomation(policyName, 'grcui-e2e-credential', 'manual')
   })


### PR DESCRIPTION
- Add `credentials` label to Ansible secrets used in tests
- Double check that the Ansible Operator isn't there before enforcing the policy to deploy it
- Close the modal if it's open at the beginning of each Automation test (Prevents false positives in the canaries)