### PR TITLE
Skip RBAC tests on ROSA clusters

### DIFF
--- a/build/rbac-setup.sh
+++ b/build/rbac-setup.sh
@@ -58,11 +58,12 @@ export OC_HUB_CLUSTER_PASS=${RBAC_PASS}
 export OC_CLUSTER_PASS=${RBAC_PASS}
 export OC_IDP=grc-e2e-htpasswd
 
-export OC_CONSOLE_URL=https://`oc get route console -n openshift-console -o=jsonpath='{.spec.host}'`
+acm_installed_namespace=`oc get subscriptions.operators.coreos.com --all-namespaces | grep advanced-cluster-management | awk '{print $1}'`
+export CYPRESS_BASE_URL=https://`oc get route multicloud-console -n $acm_installed_namespace -o=jsonpath='{.spec.host}'`
 # test oauth server and see if idp has been setup
 i=0
 while true; do
-  IDP=`curl -L -k ${OC_CONSOLE_URL} | grep ${OC_IDP}` || true
+  IDP=`curl -L -k ${CYPRESS_BASE_URL} | grep ${OC_IDP}` || true
   if [ -z ${IDP// /} ]; then
     echo "wait for idp ${OC_IDP} to take effect..."
     sleep 10
@@ -71,9 +72,9 @@ while true; do
     echo ${IDP}
     break
   fi
-  # Try for up to 4 minutes
+  # Try for up to 5 minutes
   i=$[i + 1]
-  if [[ "$i" == '24' ]]; then
+  if [[ "$i" == '30' ]]; then
     echo "timeout waiting for idp ${OC_IDP}..."
     exit 1
   fi

--- a/build/rbac-setup.sh
+++ b/build/rbac-setup.sh
@@ -57,3 +57,24 @@ export OC_CLUSTER_USER=e2e-cluster-admin-cluster
 export OC_HUB_CLUSTER_PASS=${RBAC_PASS}
 export OC_CLUSTER_PASS=${RBAC_PASS}
 export OC_IDP=grc-e2e-htpasswd
+
+export OC_CONSOLE_URL=https://`oc get route console -n openshift-console -o=jsonpath='{.spec.host}'`
+# test oauth server and see if idp has been setup
+i=0
+while true; do
+  IDP=`curl -L -k ${OC_CONSOLE_URL} | grep ${OC_IDP}` || true
+  if [ -z ${IDP// /} ]; then
+    echo "wait for idp ${OC_IDP} to take effect..."
+    sleep 10
+  else
+    echo "idp ${OC_IDP} has taken effect..."
+    echo ${IDP}
+    break
+  fi
+  # Try for up to 4 minutes
+  i=$[i + 1]
+  if [[ "$i" == '24' ]]; then
+    echo "timeout waiting for idp ${OC_IDP}..."
+    exit 1
+  fi
+done

--- a/build/run-docker-tests.sh
+++ b/build/run-docker-tests.sh
@@ -26,24 +26,6 @@ acm_installed_namespace=`oc get subscriptions.operators.coreos.com --all-namespa
 export CYPRESS_BASE_URL=https://`oc get route multicloud-console -n $acm_installed_namespace -o=jsonpath='{.spec.host}'`
 # show all envs
 printenv
-# test oauth server and see if idp has been setup
-i=0
-while true; do
-  IDP=`curl -L -k ${CYPRESS_BASE_URL} | grep ${OC_IDP}` || true
-  if [ -z ${IDP// /} ]; then
-    echo "wait for idp ${OC_IDP} to take effect..."
-    sleep 10
-  else
-    echo "idp ${OC_IDP} has taken effect..."
-    echo ${IDP}
-    break
-  fi
-  i=$[i + 1]
-  if [[ "$i" == '24' ]]; then
-    echo "timeout waiting for idp ${OC_IDP}..."
-    exit 1
-  fi
-done
 
 # run test
 export PAUSE=${PAUSE:-60}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,9 @@
     "test:cypress-headless": "export BABEL_ENV=cypress && export BROWSER=chrome && ./tests/cypress/start_cypress_tests.sh",
     "test:watch": "jest --watch",
     "test:update-snapshot": "jest --updateSnapshot",
-    "merge:coverage": "lcov-result-merger test-output/**/lcov.info ./lcov-merged.info"
+    "merge:coverage": "lcov-result-merger test-output/**/lcov.info ./lcov-merged.info",
+    "rbac:clean": "./build/rbac-clean.sh",
+    "rbac:setup": "./build/rbac-setup.sh"
   },
   "repository": {
     "type": "git",

--- a/tests/cypress/start_cypress_tests.sh
+++ b/tests/cypress/start_cypress_tests.sh
@@ -60,6 +60,15 @@ else
   oc login --server=${CYPRESS_OPTIONS_HUB_CLUSTER_URL} --token=$CYPRESS_OPTIONS_HUB_TOKEN --insecure-skip-tls-verify
 fi
 
+if [[ $CYPRESS_OPTIONS_HUB_CLUSTER_URL =~ openshiftapps.com ]]; then
+  echo "ROSA cluster detected - excluding @rbac tests"
+  if [[ -z $CYPRESS_TAGS_EXCLUDE ]]; then
+    export CYPRESS_TAGS_EXCLUDE="@rbac"
+  else
+    export CYPRESS_TAGS_EXCLUDE="@rbac|${CYPRESS_TAGS_EXCLUDE}"
+  fi
+fi
+
 acm_installed_namespace=`oc get subscriptions.operators.coreos.com --all-namespaces | grep advanced-cluster-management | awk '{print $1}'`
 RHACM_CONSOLE_URL=https://`oc get route multicloud-console -n $acm_installed_namespace -o=jsonpath='{.spec.host}'`
 

--- a/tests/cypress/start_cypress_tests.sh
+++ b/tests/cypress/start_cypress_tests.sh
@@ -7,7 +7,7 @@
 echo "Initiating tests..."
 path_to_tests=./tests/cypress/tests/*.spec.js
 if [[ "$1" == "--spec" ]] && [ ! -z "$2" ]; then
-  path_to_tests=$2
+  path_to_tests="$2"
 fi
 if [ -z "$BROWSER" ]; then
   echo "BROWSER not exported; setting to 'chrome' (options available: 'chrome', 'firefox')"
@@ -16,22 +16,22 @@ fi
 
 if [ ! -z "$OC_HUB_CLUSTER_URL" ] && [ ! -z "$OC_CLUSTER_USER" ] && [ ! -z "$OC_HUB_CLUSTER_PASS" ]; then
   echo -e "Using cypress config from Travis env variables.\n"
-  export CYPRESS_OPTIONS_HUB_CLUSTER_URL=$OC_HUB_CLUSTER_URL
-  export CYPRESS_OPTIONS_HUB_USER=$OC_CLUSTER_USER
-  export CYPRESS_OPTIONS_HUB_PASSWORD=$OC_HUB_CLUSTER_PASS
+  export CYPRESS_OPTIONS_HUB_CLUSTER_URL="$OC_HUB_CLUSTER_URL"
+  export CYPRESS_OPTIONS_HUB_USER="$OC_CLUSTER_USER"
+  export CYPRESS_OPTIONS_HUB_PASSWORD="$OC_HUB_CLUSTER_PASS"
 elif [ ! -z "$OC_CLUSTER_URL" ] && [ ! -z "$OC_CLUSTER_USER" ] && [ ! -z "$OC_CLUSTER_PASS" ]; then
   echo -e "Using cypress config from Docker env variables.\n"
-  export CYPRESS_OPTIONS_HUB_CLUSTER_URL=$OC_CLUSTER_URL
-  export CYPRESS_OPTIONS_HUB_USER=$OC_CLUSTER_USER
-  export CYPRESS_OPTIONS_HUB_PASSWORD=$OC_CLUSTER_PASS
+  export CYPRESS_OPTIONS_HUB_CLUSTER_URL="$OC_CLUSTER_URL"
+  export CYPRESS_OPTIONS_HUB_USER="$OC_CLUSTER_USER"
+  export CYPRESS_OPTIONS_HUB_PASSWORD="$OC_CLUSTER_PASS"
 elif [ ! -z "$OC_CLUSTER_URL" ] && [ ! -z "$OC_CLUSTER_TOKEN" ]; then
   echo -e "Using cypress config from Docker env variable.\n"
-  export CYPRESS_OPTIONS_HUB_CLUSTER_URL=$OC_CLUSTER_URL
-  export CYPRESS_OPTIONS_HUB_TOKEN=$OC_CLUSTER_TOKEN
+  export CYPRESS_OPTIONS_HUB_CLUSTER_URL="$OC_CLUSTER_URL"
+  export CYPRESS_OPTIONS_HUB_TOKEN="$OC_CLUSTER_TOKEN"
 else
   USER_OPTIONS_FILE=./cypressEnvConfig.yaml
   echo -e "System env variables don't exist, loading local config from '$USER_OPTIONS_FILE' file.\n"
-  if [ -f $USER_OPTIONS_FILE ]; then
+  if [ -f "$USER_OPTIONS_FILE" ]; then
     echo "Using cypress config from '$USER_OPTIONS_FILE' file."
     export CYPRESS_OPTIONS_HUB_CLUSTER_URL=`yq r $USER_OPTIONS_FILE 'options.hub.hubClusterURL'`
     export CYPRESS_OPTIONS_HUB_USER=`yq r $USER_OPTIONS_FILE 'options.hub.user'`
@@ -48,36 +48,36 @@ fi
 if [ -z "$MANAGED_CLUSTER_NAME" ]; then
   echo "MANAGED_CLUSTER_NAME not set."
 else
-  export CYPRESS_MANAGED_CLUSTER_NAME=$MANAGED_CLUSTER_NAME
+  export CYPRESS_MANAGED_CLUSTER_NAME="$MANAGED_CLUSTER_NAME"
   echo "MANAGED_CLUSTER_NAME is set, set CYPRESS_MANAGED_CLUSTER_NAME to $MANAGED_CLUSTER_NAME"
   export CLUSTER_LABEL_SELECTOR="-l name=$MANAGED_CLUSTER_NAME"
 fi
 
 echo -e "\nLogging into Kube API server\n"
-if [ -z $CYPRESS_OPTIONS_HUB_TOKEN ]; then
-  oc login --server=${CYPRESS_OPTIONS_HUB_CLUSTER_URL} -u $CYPRESS_OPTIONS_HUB_USER -p $CYPRESS_OPTIONS_HUB_PASSWORD --insecure-skip-tls-verify
+if [ -z "$CYPRESS_OPTIONS_HUB_TOKEN" ]; then
+  oc login --server="$CYPRESS_OPTIONS_HUB_CLUSTER_URL" -u "$CYPRESS_OPTIONS_HUB_USER" -p "$CYPRESS_OPTIONS_HUB_PASSWORD" --insecure-skip-tls-verify
 else
-  oc login --server=${CYPRESS_OPTIONS_HUB_CLUSTER_URL} --token=$CYPRESS_OPTIONS_HUB_TOKEN --insecure-skip-tls-verify
+  oc login --server="$CYPRESS_OPTIONS_HUB_CLUSTER_URL" --token="$CYPRESS_OPTIONS_HUB_TOKEN" --insecure-skip-tls-verify
 fi
 
-if [[ $CYPRESS_OPTIONS_HUB_CLUSTER_URL =~ openshiftapps.com ]]; then
+if [[ "${CYPRESS_OPTIONS_HUB_CLUSTER_URL}" =~ "openshiftapps.com" ]]; then
   echo "ROSA cluster detected - excluding @rbac tests"
-  if [[ -z $CYPRESS_TAGS_EXCLUDE ]]; then
+  if [[ -z "$CYPRESS_TAGS_EXCLUDE" ]]; then
     export CYPRESS_TAGS_EXCLUDE="@rbac"
   else
-    export CYPRESS_TAGS_EXCLUDE="@rbac|${CYPRESS_TAGS_EXCLUDE}"
+    export CYPRESS_TAGS_EXCLUDE="@rbac|$CYPRESS_TAGS_EXCLUDE"
   fi
 fi
 
 acm_installed_namespace=`oc get subscriptions.operators.coreos.com --all-namespaces | grep advanced-cluster-management | awk '{print $1}'`
 RHACM_CONSOLE_URL=https://`oc get route multicloud-console -n $acm_installed_namespace -o=jsonpath='{.spec.host}'`
 
-export CYPRESS_BASE_URL=${CYPRESS_BASE_URL:-$RHACM_CONSOLE_URL}
-export CYPRESS_coverage=${CYPRESS_coverage:-"false"}
-export CYPRESS_RESOURCE_ID=${CYPRESS_RESOURCE_ID:-"$(date +"%s")"}
-export CYPRESS_RBAC_PASS=$RBAC_PASS
-export CYPRESS_FAIL_FAST_PLUGIN=${CYPRESS_FAIL_FAST_PLUGIN:-"true"}
-export CYPRESS_OC_IDP=$OC_IDP
+export CYPRESS_BASE_URL="${CYPRESS_BASE_URL:-$RHACM_CONSOLE_URL}"
+export CYPRESS_coverage="${CYPRESS_coverage:-"false"}"
+export CYPRESS_RESOURCE_ID="${CYPRESS_RESOURCE_ID:-"$(date +"%s")"}"
+export CYPRESS_RBAC_PASS="$RBAC_PASS"
+export CYPRESS_FAIL_FAST_PLUGIN="${CYPRESS_FAIL_FAST_PLUGIN:-"true"}"
+export CYPRESS_OC_IDP="$OC_IDP"
 echo -e "Running Cypress tests with the following environment:\n"
 echo -e "\tCYPRESS_RESOURCE_ID (used for policy identifier) : $CYPRESS_RESOURCE_ID"
 echo -e "\tCYPRESS_BASE_URL (used as cypress entry point URL) : $CYPRESS_BASE_URL"
@@ -94,7 +94,7 @@ echo -e "\tCLUSTER_LABEL_SELECTOR          : $CLUSTER_LABEL_SELECTOR"
 [ -n "$CYPRESS_RBAC_PASS" ] && echo -e "RBAC_PASS set" || echo -e "Error: RBAC_PASS is not set"
 
 # save a list of available clusters to .tests/cypress/config/clusters.yaml file so tests can use it
-oc get managedclusters $CLUSTER_LABEL_SELECTOR -o custom-columns='name:.metadata.name,available:.status.conditions[?(@.reason=="ManagedClusterAvailable")].status,vendor:.metadata.labels.vendor' --no-headers | awk '/True/ { printf "%s:\n  vendor: %s\n", $1, $3 }' > ./tests/cypress/config/clusters.yaml
+oc get managedclusters "$CLUSTER_LABEL_SELECTOR" -o custom-columns='name:.metadata.name,available:.status.conditions[?(@.reason=="ManagedClusterAvailable")].status,vendor:.metadata.labels.vendor' --no-headers | awk '/True/ { printf "%s:\n  vendor: %s\n", $1, $3 }' > ./tests/cypress/config/clusters.yaml
 echo "Available clusters stored in ./tests/cypress/config/clusters.yaml:"
 cat ./tests/cypress/config/clusters.yaml
 
@@ -110,9 +110,9 @@ else
 fi
 
 if [ "$NODE_ENV" == "dev" ]; then
-  npx cypress run --browser $BROWSER $HEADLESS --spec "$path_to_tests" --reporter cypress-multi-reporters
+  npx cypress run --browser "$BROWSER" "$HEADLESS" --spec "$path_to_tests" --reporter cypress-multi-reporters
 elif [ "$NODE_ENV" == "debug" ]; then
-  npx cypress open --browser $BROWSER --config numTestsKeptInMemory=0
+  npx cypress open --browser "$BROWSER" --config numTestsKeptInMemory=0
 else
-  cypress run --browser $BROWSER $HEADLESS --spec "$path_to_tests" --reporter cypress-multi-reporters
+  cypress run --browser "$BROWSER" "$HEADLESS" --spec "$path_to_tests" --reporter cypress-multi-reporters
 fi


### PR DESCRIPTION
See https://github.com/open-cluster-management/backlog/issues/14250 for some comments on why skipping the tests might be the right call for now.

An alternative that I was looking at was detecting when the IDP was removed, and setting it up again. Since right now the IDP is only removed periodically, it might be stable enough to get the tests done. I abandoned that, but exposing the rbac-setup as an npm script would make it easier in the future (and could make other things easier). The problem with the approach is that if the IDP is removed more quickly, then it will never work.