### PR TITLE
Update card style

### DIFF
--- a/src-web/scss/module-grc-cards.scss
+++ b/src-web/scss/module-grc-cards.scss
@@ -126,7 +126,7 @@
 
           .card-name {
             height: 3.75rem;
-            padding: 1.5rem;
+            padding: 1rem;
             font-size: 1rem;
             font-weight: bold;
             .textWithTruncation {

--- a/src-web/scss/module-grc-cards.scss
+++ b/src-web/scss/module-grc-cards.scss
@@ -119,7 +119,7 @@
           display: flex;
           flex-direction: column;
           height: 12.75rem;
-          min-width: 23.125rem;
+          min-width: 18.5rem;
           background-color: var(--pf-global--BackgroundColor--100);
           box-shadow: rgba(0, 0, 0, 0.1) 0rem 0.0625rem 0.125rem 0rem;
           border: 1px var(--pf-global--BackgroundColor--200);


### PR DESCRIPTION
I think this styling issue came up because of the NavBar being collapsible. This should address it.

Addresses https://github.com/open-cluster-management/backlog/issues/13752

NavBar Open:
![image](https://user-images.githubusercontent.com/19750917/126808774-332591ea-37cf-4e48-937c-8d82254371d0.png)

NavBar Closed:
![image](https://user-images.githubusercontent.com/19750917/126808843-e01c2645-02fe-44b3-a526-db1d7c16af54.png)
