### PR TITLE
Update Chromedriver to match current Chrome version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4077,9 +4077,9 @@
       "dev": true
     },
     "@types/yauzl": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.1.tgz",
-      "integrity": "sha512-A1b8SU4D10uoPjwb0lnHmmu8wZhR9d+9o2PKBQT2jU5YPTKsxac6M2qGAdY7VcL+dHHhARVUDmeg0rOrcd9EjA==",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.2.tgz",
+      "integrity": "sha512-8uALY5LTvSuHgloDVUvWP3pIauILm+8/0pDMokuDYIoNsOkSwd5AiHBTSEJjKTDcZr5z8UpgOWZkxBF4iJftoA==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -6090,9 +6090,9 @@
       }
     },
     "chromedriver": {
-      "version": "89.0.0",
-      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-89.0.0.tgz",
-      "integrity": "sha512-+DVYp3+m6tZUYTMl9fEgCZIDk9YBTcHws82nIV1JYwusu51zRITA0oeNzuPyFhuK7ageFnnKCDviH2BL5I4M0w==",
+      "version": "91.0.1",
+      "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-91.0.1.tgz",
+      "integrity": "sha512-9LktpHiUxM4UWUsr+jI1K1YKx2GENt6BKKJ2mibPj1Wc6ODzX/3fFIlr8CZ4Ftuyga+dHTTbAyPWKwKvybEbKA==",
       "dev": true,
       "requires": {
         "@testim/chrome-version": "^1.0.7",
@@ -6100,7 +6100,6 @@
         "del": "^6.0.0",
         "extract-zip": "^2.0.1",
         "https-proxy-agent": "^5.0.0",
-        "mkdirp": "^1.0.4",
         "proxy-from-env": "^1.1.0",
         "tcp-port-used": "^1.0.1"
       },
@@ -6122,9 +6121,9 @@
           }
         },
         "globby": {
-          "version": "11.0.2",
-          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.2.tgz",
-          "integrity": "sha512-2ZThXDvvV8fYFRVIxnrMQBipZQDr7MxKAmQK1vujaj9/7eF0efG7BPUKJ7jP7G5SLF37xKDXvO4S/KKLj/Z0og==",
+          "version": "11.0.4",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
+          "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
           "dev": true,
           "requires": {
             "array-union": "^2.1.0",
@@ -11665,9 +11664,9 @@
       }
     },
     "is2": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/is2/-/is2-2.0.6.tgz",
-      "integrity": "sha512-+Z62OHOjA6k2sUDOKXoZI3EXv7Fb1K52jpTBLbkfx62bcUeSsrTBLhEquCRDKTx0XE5XbHcG/S2vrtE3lnEDsQ==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/is2/-/is2-2.0.7.tgz",
+      "integrity": "sha512-4vBQoURAXC6hnLFxD4VW7uc04XiwTTl/8ydYJxKvPwkWQrSjInkuM5VZVg6BGr1/natq69zDuvO9lGpLClJqvA==",
       "dev": true,
       "requires": {
         "deep-is": "^0.1.3",

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "@slack/web-api": "^5.15.0",
     "babel-eslint": "^10.1.0",
     "babel-jest": "^26.6.3",
-    "chromedriver": "^89.0.0",
+    "chromedriver": "^91.0.0",
     "cross-fetch": "^3.0.6",
     "cypress": "^6.2.1",
     "cypress-multi-reporters": "^1.4.0",


### PR DESCRIPTION
Addresses Nightwatch test failures in the `2.2` canary:
https://app.travis-ci.com/github/open-cluster-management/canary/jobs/526369625#L1547-L1551

Discussion: https://coreos.slack.com/archives/C0140DCKJ5A/p1627045752192000

I investigated setting the Chromedriver version or the installed Chrome version in our test image, but it looks like Google doesn't host older versions of Chrome, so updating the version is the way to go.