### PR TITLE
Change dev setup to use real RHACM grc-ui-api instead of local instance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .vscode
 .idea
+.env
 *.log
 .DS_Store
 node_modules

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ The UI Platform is developed as an isomorphic React application. View the list o
          oc whoami -t
          ```
     
-    Note: If you want to develop against both the grc-ui & the grc-ui-api you can start the API server and configure the grc-ui to query against the local grc-ui-api server. See: [`grc-ui-api`](https://github.com/open-cluster-management/grc-ui-api)
+    Note: If you want to develop against both the grc-ui & the grc-ui-api you can start the API server and configure the grc-ui to query against the local grc-ui-api server. If you have already sourced the `.env` file you can run `unset grcUiApiUrl` to revert to using the default localhost url for communication with grc-ui-api. See the following on how to setup the api server: [`grc-ui-api`](https://github.com/open-cluster-management/grc-ui-api).
 
 2. Start the server for production by running the following command:
 

--- a/README.md
+++ b/README.md
@@ -41,19 +41,19 @@ The UI Platform is developed as an isomorphic React application. View the list o
 
 **SECURITY WARNING:** The GRC UI provides an SSL certificate in `/sslcert` that is open to the public. In order to run this in production, you'll need to replace these certificates. For our production builds, we replace these certificates using its Helm chart.
 
-1. The following environment variables need to be set to point to a running Openshift cluster. Your environment might resemble the following content:
+1. Setup environment
+   You need:
+   - to be connected to a OpenShift 4.x.x cluster
+   - to have Advanced Cluster Management installed on the cluster
+   - Run one of the following commands:
 
-   ```json
-   {
-      "NODE_ENV": "development",
-      "headerUrl": "<url-to-rhacm-console>",
-      "API_SERVER_URL": "<url-to-openshift-apiserver>",
-      "SERVICEACCT_TOKEN": "<openshift-token-to-authenticate>",
-      "OAUTH2_CLIENT_ID": "multicloudingress",
-      "OAUTH2_CLIENT_SECRET": "multicloudingresssecret",
-      "OAUTH2_REDIRECT_URL": "https://localhost:3000/multicloud/policies/auth/callback",
-   }
    ```
+   npm run setup
+   OR
+   ./setup-env.sh
+   ```
+
+   This will create a `.env` file in the main directory containing the environment variables. You can run `source .env` to set the variables for use.
 
    The `SERVICEACCT_TOKEN` expires so if you need to get a new one:
    - From the UI...
@@ -64,6 +64,8 @@ The UI Platform is developed as an isomorphic React application. View the list o
          ```bash
          oc whoami -t
          ```
+    
+    Note: If you want to develop against both the grc-ui & the grc-ui-api you can start the API server and configure the grc-ui to query against the local grc-ui-api server. See: [`grc-ui-api`](https://github.com/open-cluster-management/grc-ui-api)
 
 2. Start the server for production by running the following command:
 
@@ -77,8 +79,6 @@ The UI Platform is developed as an isomorphic React application. View the list o
    npm run build:watch
    npm run start
    ```
-
-   - Start the API server alongside it. See: [`grc-ui-api`](https://github.com/open-cluster-management/grc-ui-api)
 
 5.Open a browser to `https://localhost:3000/multicloud/policies` and log in using your cluster admin credentials.
 

--- a/build/run-e2e-tests.sh
+++ b/build/run-e2e-tests.sh
@@ -37,7 +37,6 @@ $DIR/cluster-clean-up.sh managed
 echo "Export envs to run e2e"
 export SERVICEACCT_TOKEN=`${BUILD_HARNESS_PATH}/vendor/oc whoami --show-token`
 acm_installed_namespace=`oc get subscriptions.operators.coreos.com --all-namespaces | grep advanced-cluster-management | awk '{print $1}'`
-export headerUrl=https://`oc get route multicloud-console -n $acm_installed_namespace -o=jsonpath='{.spec.host}'`
 export NODE_ENV=development
 export API_SERVER_URL=$OC_HUB_CLUSTER_URL
 export OAUTH2_REDIRECT_URL=${OAUTH2_REDIRECT_URL:-"https://localhost:3000/multicloud/policies/auth/callback"}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "app.js",
   "scripts": {
+    "setup": "./setup-env.sh",
     "start": "cross-env NODE_ENV=development node app.js",
     "start:production": "cross-env NODE_ENV=production node app.js",
     "start:instrument": "nyc --reporter=text --reporter=lcov --report-dir=./test-output/server/coverage node app.js",

--- a/server/config/config-defaults.json
+++ b/server/config/config-defaults.json
@@ -6,7 +6,6 @@
     "docUrl": "https://github.com/open-cluster-management/rhacm-docs",
     "feature_search-api": true,
     "grcUiApiUrl": "",
-    "headerUrl":"https://management-ingress",
     "httpPort": 3000,
     "OAUTH2_CLIENT_ID": "",
     "OAUTH2_CLIENT_SECRET": "",

--- a/setup-env.sh
+++ b/setup-env.sh
@@ -7,29 +7,29 @@
 ######################
 
 NODE_ENV=development
-echo NODE_ENV=$NODE_ENV >> .env
+echo export NODE_ENV=$NODE_ENV >> .env
 
 API_SERVER_URL=`oc get infrastructure cluster -o jsonpath={.status.apiServerURL}`
-echo API_SERVER_URL=$API_SERVER_URL >> .env
+echo export API_SERVER_URL=$API_SERVER_URL >> .env
 
 SERVICEACCT_TOKEN=$(oc whoami -t)
-echo SERVICEACCT_TOKEN=$SERVICEACCT_TOKEN >> .env
+echo export SERVICEACCT_TOKEN=$SERVICEACCT_TOKEN >> .env
 
 OCM_ADDRESS=https://`oc -n open-cluster-management get route multicloud-console -o json | jq -r '.spec.host'`
 grcUiApiUrl=$OCM_ADDRESS/multicloud/policies/graphql
-echo grcUiApiUrl=$grcUiApiUrl >> .env
+echo export grcUiApiUrl=$grcUiApiUrl >> .env
 
 searchApiUrl=$OCM_ADDRESS/multicloud/policies/search/graphql
-echo searchApiUrl=$searchApiUrl >> .env
+echo export searchApiUrl=$searchApiUrl >> .env
 
 OAUTH2_CLIENT_ID=multicloudingress
-echo OAUTH2_CLIENT_ID=$OAUTH2_CLIENT_ID >> .env
+echo export OAUTH2_CLIENT_ID=$OAUTH2_CLIENT_ID >> .env
 
 OAUTH2_CLIENT_SECRET=multicloudingresssecret
-echo OAUTH2_CLIENT_SECRET=$OAUTH2_CLIENT_SECRET >> .env
+echo export OAUTH2_CLIENT_SECRET=$OAUTH2_CLIENT_SECRET >> .env
 
 OAUTH2_REDIRECT_URL=https://localhost:3000/multicloud/policies/auth/callback
-echo OAUTH2_REDIRECT_URL=$OAUTH2_REDIRECT_URL >> .env
+echo export OAUTH2_REDIRECT_URL=$OAUTH2_REDIRECT_URL >> .env
 
 REDIRECT_URIS=$(oc get OAuthClient $OAUTH2_CLIENT_ID -o json | jq -c "[.redirectURIs[], \"$OAUTH2_REDIRECT_URL\"] | unique")
 oc patch OAuthClient multicloudingress --type json -p "[{\"op\": \"add\", \"path\": \"/redirectURIs\", \"value\": ${REDIRECT_URIS}}]"

--- a/setup-env.sh
+++ b/setup-env.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Copyright (c) 2021 Red Hat, Inc.
+# Copyright Contributors to the Open Cluster Management project
+
+######################
+# configure env
+######################
+
+NODE_ENV=development
+echo NODE_ENV=$NODE_ENV >> .env
+
+API_SERVER_URL=`oc get infrastructure cluster -o jsonpath={.status.apiServerURL}`
+echo API_SERVER_URL=$API_SERVER_URL >> .env
+
+SERVICEACCT_TOKEN=$(oc whoami -t)
+echo SERVICEACCT_TOKEN=$SERVICEACCT_TOKEN >> .env
+
+OCM_ADDRESS=https://`oc -n open-cluster-management get route multicloud-console -o json | jq -r '.spec.host'`
+grcUiApiUrl=$OCM_ADDRESS/multicloud/policies/graphql
+echo grcUiApiUrl=$grcUiApiUrl >> .env
+
+searchApiUrl=$OCM_ADDRESS/multicloud/policies/search/graphql
+echo searchApiUrl=$searchApiUrl >> .env
+
+OAUTH2_CLIENT_ID=multicloudingress
+echo OAUTH2_CLIENT_ID=$OAUTH2_CLIENT_ID >> .env
+
+OAUTH2_CLIENT_SECRET=multicloudingresssecret
+echo OAUTH2_CLIENT_SECRET=$OAUTH2_CLIENT_SECRET >> .env
+
+OAUTH2_REDIRECT_URL=https://localhost:3000/multicloud/policies/auth/callback
+echo OAUTH2_REDIRECT_URL=$OAUTH2_REDIRECT_URL >> .env
+
+REDIRECT_URIS=$(oc get OAuthClient $OAUTH2_CLIENT_ID -o json | jq -c "[.redirectURIs[], \"$OAUTH2_REDIRECT_URL\"] | unique")
+oc patch OAuthClient multicloudingress --type json -p "[{\"op\": \"add\", \"path\": \"/redirectURIs\", \"value\": ${REDIRECT_URIS}}]"

--- a/tests/cypress/README.md
+++ b/tests/cypress/README.md
@@ -14,7 +14,6 @@ The procedure basically follows the setup described in
 1. Export environment variables necessary for a server to run and login. E.g.
 ```
 export NODE_ENV="development"
-export headerUrl="https://multicloud-console.apps.YOURSERVER.red-chesterfield.com"  # replace with your server name
 export API_SERVER_URL="https://api.YOURSERVER.red-chesterfield.com:6443"  # replace with your server name
 export SERVICEACCT_TOKEN="sha256~12345...abcde"  # replace with your token
 export OAUTH2_CLIENT_ID="multicloudingress"


### PR DESCRIPTION
Signed-off-by: Zack Layne <zlayne@redhat.com>

Hey @dhaiducek, I created this PR so the grc-ui will use a `setup-env` script to configure grc-ui to run against a real RHACM grc-ui-api service rather than needing a local grc-ui-api running in parallel.

I have also removed the `headerUrl` env var as I didn't see it used, and noticed the `searchApiUrl` var isnt used either. Would both of these be safe to remove from the codebase or am I missing something?

Please let me know if these changes makes sense, thanks!