### PR TITLE
Update the expected message on iampolicies

### DIFF
--- a/tests/cypress/config/violation-patterns.yaml
+++ b/tests/cypress/config/violation-patterns.yaml
@@ -53,8 +53,8 @@ gatekeeper-operator-subscription:
 # IamPolicy specification
 [POLICYNAME]-limit-clusteradmin:
  ?: "(notification|violation)"
- 0: "Number of users with clusteradmin role is 0 above the specified limit"
- 1: "Number of users with clusteradmin role is [0-9]+ above the specified limit"
+ 0: "(The n|N)umber of users with (the cluster-|cluster)admin role is (at least )?0 above the specified limit"
+ 1: "(The n|N)umber of users with (the cluster-|cluster)admin role is (at least )?[0-9]+ above the specified limit"
 # ImageManifestVulnPolicy specification
 [POLICYNAME]-image-vulnerability:
  ?: "(notification|violation)"


### PR DESCRIPTION
The message changed in:
https://github.com/open-cluster-management/iam-policy-controller/pull/68

The regex used here should match the new message, as well as the old
message, because of some details in the merge tests.

Signed-off-by: Justin Kulikauskas <jkulikau@redhat.com>

Replaces https://github.com/open-cluster-management/grc-ui/pull/722