### PR TITLE
Close automation modal if it's open

### DIFF
--- a/tests/cypress/support/views.js
+++ b/tests/cypress/support/views.js
@@ -1556,6 +1556,15 @@ export const action_scheduleAutomation = (uName, credentialName, mode) => {
   })
   // after successfully creating automation
   // panel will automatically closed and need to reopen it
+
+  // In case there's an "automation already exists" error,
+  // check for open Automation modal and close it if it's open
+  if (Cypress.$('#automation-resource-panel').length === 1) {
+    cy.get('#automation-resource-panel').within(() => {
+      cy.get('button[aria-label="Close"]').click()
+    })
+  }
+
   cy.CheckGrcMainPage()
     .doTableSearch(uName)
     .get('.grc-view-by-policies-table').within(() => {


### PR DESCRIPTION
It looks like we might be getting an odd "automation already exists" error. Since we're mocking the automation anyway, I've added a check to close the modal to see if that resolves the test errors.
![image](https://user-images.githubusercontent.com/19750917/130624711-f0e4d7b2-62ff-45bd-bb51-2fa27366d0d8.png)
