### PR TITLE
Clean hub post-test

### DIFF
--- a/build/run-docker-tests.sh
+++ b/build/run-docker-tests.sh
@@ -24,8 +24,6 @@ fi
 export FAIL_FAST=${FAIL_FAST:-false}
 acm_installed_namespace=`oc get subscriptions.operators.coreos.com --all-namespaces | grep advanced-cluster-management | awk '{print $1}'`
 export CYPRESS_BASE_URL=https://`oc get route multicloud-console -n $acm_installed_namespace -o=jsonpath='{.spec.host}'`
-# show all envs
-printenv
 
 # run test
 export PAUSE=${PAUSE:-60}
@@ -41,3 +39,13 @@ else
   export CYPRESS_FAIL_FAST_PLUGIN=false
 fi
 npm run test:cypress-headless
+
+if [[ "${SKIP_CLEANUP}" != "true" ]]; then
+  echo "===== E2E Cleanup ====="
+  ${DIR}/cluster-clean-up.sh hub
+  if [ -z ${RBAC_PASS} ]; then
+    echo "RBAC_PASS not set. Skipping RBAC cleanup."
+  else
+    ./build/rbac-clean.sh
+  fi
+fi

--- a/build/run-docker-tests.sh
+++ b/build/run-docker-tests.sh
@@ -42,7 +42,7 @@ npm run test:cypress-headless
 
 if [[ "${SKIP_CLEANUP}" != "true" ]]; then
   echo "===== E2E Cleanup ====="
-  ${DIR}/cluster-clean-up.sh hub
+  ./build/cluster-clean-up.sh hub
   if [ -z ${RBAC_PASS} ]; then
     echo "RBAC_PASS not set. Skipping RBAC cleanup."
   else

--- a/build/run-e2e-tests.sh
+++ b/build/run-e2e-tests.sh
@@ -114,3 +114,10 @@ rm ${DIR}/tmpkube
 
 # sed -i 's|SF:|SF:'"$(pwd)"/'|g' test-output/server/coverage/lcov.info
 # sed -i 's|SF:|SF:'"$(pwd)"/'|g' test-output/cypress/coverage/lcov.info
+
+echo "===== E2E Cleanup ====="
+echo "* Clean up hub"
+export KUBECONFIG=${HUB_KUBE}
+
+${DIR}/cluster-clean-up.sh hub
+${DIR}/rbac-clean.sh ${DIR}/..

--- a/build/run-e2e-tests.sh
+++ b/build/run-e2e-tests.sh
@@ -114,10 +114,3 @@ rm ${DIR}/tmpkube
 
 # sed -i 's|SF:|SF:'"$(pwd)"/'|g' test-output/server/coverage/lcov.info
 # sed -i 's|SF:|SF:'"$(pwd)"/'|g' test-output/cypress/coverage/lcov.info
-
-echo "===== E2E Cleanup ====="
-echo "* Clean up hub"
-export KUBECONFIG=${HUB_KUBE}
-
-${DIR}/cluster-clean-up.sh hub
-${DIR}/rbac-clean.sh ${DIR}/..


### PR DESCRIPTION
I think running our cleanup script should clean any resources that are left over. I've made it toggle-able in case anyone wants to run it and double check resources that remain. I am a little concerned we're cleaning up resources that might be used to diagnose issues, but the pod logs should still be available.

Addresses:
- https://github.com/open-cluster-management/backlog/issues/15528