### PR TITLE
Cypress - Wait after login preflight check regardless

### DIFF
--- a/tests/cypress/start_cypress_tests.sh
+++ b/tests/cypress/start_cypress_tests.sh
@@ -66,10 +66,10 @@ while [[ "${FAILED}" == "true" ]] && (( ATTEMPTS != MAX_ATTEMPTS )); do
   fi
   if [[ "$?" != "0" ]]; then
     echo "* Error logging in to cluster. Trying again in ${INTERVAL}s (Retry $((++ATTEMPTS))/${MAX_ATTEMPTS})"
-    sleep ${INTERVAL}
   else
     FAILED="false"
   fi
+  sleep ${INTERVAL}
 done
 if [[ "${FAILED}" == "true" ]]; then
   echo -e "\nERROR: Failed to log in to cluster. The following commands will likely fail.\n"


### PR DESCRIPTION
We're hitting a scenario where the IDP doesn't actually exist in the UI for the first test even though the login with the IDP user succeeded with the CLI. This moves the wait in the preflight login retries to run regardless of success or failure.