### PR TITLE
remove /status from url since that tab no longer exists

### DIFF
--- a/src-web/containers/definitions/PageDefinitions.js
+++ b/src-web/containers/definitions/PageDefinitions.js
@@ -174,7 +174,7 @@ const policyTemplateDetailsPage = ({ name, namespace, cluster, apiGroup, version
     breadcrumb: [
       { text: msgs.get(policiesMsg, locale), to: config.contextPath },
       { text: name, to: `${config.contextPath}/all/${namespace}/${name}`},
-      { text: msgs.get('table.header.status', locale), to: `${config.contextPath}/all/${namespace}/${name}/status` },
+      { text: msgs.get('table.header.status', locale), to: `${config.contextPath}/all/${namespace}/${name}` },
       { text: template, to: template }
     ],
     children: (props) => <PolicyTemplateDetailsView {...props} selfLink={selfLink} />

--- a/src-web/containers/definitions/PageDefinitions.js
+++ b/src-web/containers/definitions/PageDefinitions.js
@@ -174,7 +174,6 @@ const policyTemplateDetailsPage = ({ name, namespace, cluster, apiGroup, version
     breadcrumb: [
       { text: msgs.get(policiesMsg, locale), to: config.contextPath },
       { text: name, to: `${config.contextPath}/all/${namespace}/${name}`},
-      { text: msgs.get('table.header.status', locale), to: `${config.contextPath}/all/${namespace}/${name}` },
       { text: template, to: template }
     ],
     children: (props) => <PolicyTemplateDetailsView {...props} selfLink={selfLink} />


### PR DESCRIPTION
related issue: https://github.com/open-cluster-management/backlog/issues/16581
Signed-off-by: rhowingt@redhat.com <rhowingt@redhat.com>