### PR TITLE
Wait for oauth pods to restart for IDP

### DIFF
--- a/build/rbac-setup.sh
+++ b/build/rbac-setup.sh
@@ -61,3 +61,7 @@ export OC_HUB_CLUSTER_PASS=${RBAC_PASS}
 export OC_CLUSTER_PASS=${RBAC_PASS}
 export OC_IDP=grc-e2e-htpasswd
 
+echo "* Waiting for oauth pod restart"
+# Sleep instead of deleting pods to prevent authentication disruption in the environment
+sleep 15
+./build/wait_for.sh pod -l app=oauth-openshift -A

--- a/tests/cypress/start_cypress_tests.sh
+++ b/tests/cypress/start_cypress_tests.sh
@@ -53,7 +53,7 @@ else
   export CLUSTER_LABEL_SELECTOR="-l name=$MANAGED_CLUSTER_NAME"
 fi
 
-echo -e "\nLogging into Kube API server\n"
+echo -e "\nLogging into Kube API server...\n"
 ATTEMPTS=0
 MAX_ATTEMPTS=10
 INTERVAL=20
@@ -84,12 +84,14 @@ if [[ "${CYPRESS_OPTIONS_HUB_CLUSTER_URL}" =~ "openshiftapps.com" ]]; then
   fi
 fi
 
-# Determine whether an IDP is configured
+# We're assuming here both that 'kubeadmin' is still enabled and that the IDP is configured properly
+echo -e "\nDetermining whether any IDPs are configured..."
 IDP=$(oc get oauth -o jsonpath={.items[*].spec.identityProviders})
 if [[ -n "${IDP}" ]] && [[ "${IDP}" != "[]" ]]; then
   export CYPRESS_OC_IDP_CONFIGURED="true"
 fi
 
+echo -e "\nFetching ACM namespace and console URL...\n"
 acm_installed_namespace=`oc get subscriptions.operators.coreos.com --all-namespaces | grep advanced-cluster-management | awk '{print $1}'`
 RHACM_CONSOLE_URL=https://`oc get route multicloud-console -n $acm_installed_namespace -o=jsonpath='{.spec.host}'`
 


### PR DESCRIPTION
Based guidance from @mprahl, I've updated our RBAC setup to include a check for the restarting oauth pods. To me this seems like it'd be more reliable if the URL for oauth ever changes again, which was preventing our tests from running at all when it happened before.