### PR TITLE
Only apply resources used by rbac test on hub

### DIFF
--- a/tests/cypress/config/RBAC/policy-config.yaml
+++ b/tests/cypress/config/RBAC/policy-config.yaml
@@ -4,17 +4,20 @@ test-[ID]-e2e-rbac-test-1:
   namespace: e2e-rbac-test-1
   specifications:
     - 'LimitRange - Limit container memory usage'
-  cluster_binding: [] # skip cluster_binding selection if empty
+  cluster_binding: 
+    - 'name: "local-cluster"'
 
 test-[ID]-e2e-rbac-test-2:
   namespace: e2e-rbac-test-2
   specifications:
     - 'IamPolicy'
-  cluster_binding: [] # skip cluster_binding selection if empty
+  cluster_binding: 
+    - 'name: "local-cluster"'
 
 disabled-policy:
   namespace: e2e-rbac-test-1
   specifications:
     - 'IamPolicy'
-  cluster_binding: [] # skip cluster_binding selection if empty
+  cluster_binding: 
+    - 'name: "local-cluster"'
   disable: True

--- a/tests/cypress/support/tests.js
+++ b/tests/cypress/support/tests.js
@@ -425,6 +425,10 @@ export const test_userPermissionsPageContentCheck = (userName, userPassword, IDP
       })
       // collapse the drop down again
       cy.get('@dropdown').click()
+      // if namespaced, remove cluster_binding from PolicyConf as namespaced user doesn't have access to it
+      if (namespaced) {
+        delete newPolicyConf['cluster_binding']
+      }
       // now create a test policy
       cy.createPolicyFromSelection(newPolicyName, true, newPolicyConf)
       .verifyPolicyInListing(newPolicyName, newPolicyConf, 'disabled')


### PR DESCRIPTION
Signed-off-by: Yu Cao <ycao@redhat.com>
The resource used in RBAC test shouldn't need to be applied to all managed clusters. This should help us seeing less often below canary issue.

closes https://github.com/open-cluster-management/backlog/issues/16744