### PR TITLE
Copy Cypress output to the Prow artifacts directory

### DIFF
--- a/Dockerfile.e2etest
+++ b/Dockerfile.e2etest
@@ -30,6 +30,7 @@ RUN npm install \
     cypress-wait-until \
     cypress-fail-fast \
     @cypress/code-coverage \
+    del \
     mocha \
     mocha-junit-reporter \
     mochawesome \

--- a/build/run-e2e-tests.sh
+++ b/build/run-e2e-tests.sh
@@ -73,10 +73,18 @@ echo "* Launching Cypress E2E test"
 touch ${DIR}/tmpkube
 export KUBECONFIG=${DIR}/tmpkube
 # Run E2E tests
-npm run test:cypress-headless
+npm run test:cypress-headless || ERROR_CODE=$?
 # Clean up the kubeconfig
 unset KUBECONFIG
 rm ${DIR}/tmpkube
+
+if [[ -n "${ARTIFACT_DIR}" ]]; then
+  echo "* Copying 'test-output/cypress/' directory to '${ARTIFACT_DIR}'..."
+  cp -r $DIR/../test-output/* ${ARTIFACT_DIR}
+fi
+
+# Since we obfuscated the error code on the test run, we'll manually exit here with the collected code
+exit ${ERROR_CODE}
 
 # kill the node process to let nyc generate coverage report
 # NODE_PROCESS=$(ps -ef | grep 'node app.js' | grep -v grep)

--- a/tests/cypress/plugins/index.js
+++ b/tests/cypress/plugins/index.js
@@ -7,6 +7,7 @@
  * @type {Cypress.PluginConfig}
  */
 
+const del = require('del')
 const glob = require('glob')
 const path = require('path')
 const getConfig = require('../config').getConfig
@@ -29,6 +30,15 @@ module.exports = (on, config) => {
   require('cypress-terminal-report/src/installLogsPrinter')(on)
 
   require('cypress-fail-fast/plugin')(on, config)
+
+  // Delete videos for test suites with no failures
+  on('after:spec', (spec, results) => {
+    if (results && results.video) {
+      if (results.stats && results.stats.failures === 0) {
+        return del(results.video)
+      }
+    }
+  })
 
   return config
 }


### PR DESCRIPTION
If this works, I'll have to investigate where we use the `run-e2e-tests.sh` script and whether these commands can live inside the script or should be moved to the Prow configuration.