### PR TITLE
Only apply resources used by rbac test on hub

### DIFF
--- a/tests/cypress/config/RBAC/policy-config.yaml
+++ b/tests/cypress/config/RBAC/policy-config.yaml
@@ -4,17 +4,15 @@ test-[ID]-e2e-rbac-test-1:
   namespace: e2e-rbac-test-1
   specifications:
     - 'LimitRange - Limit container memory usage'
-  cluster_binding: [] # skip cluster_binding selection if empty
 
 test-[ID]-e2e-rbac-test-2:
   namespace: e2e-rbac-test-2
   specifications:
     - 'IamPolicy'
-  cluster_binding: [] # skip cluster_binding selection if empty
 
 disabled-policy:
   namespace: e2e-rbac-test-1
   specifications:
     - 'IamPolicy'
-  cluster_binding: [] # skip cluster_binding selection if empty
+  cluster_binding: []
   disable: True

--- a/tests/cypress/config/RBAC/policy-config.yaml
+++ b/tests/cypress/config/RBAC/policy-config.yaml
@@ -14,5 +14,5 @@ disabled-policy:
   namespace: e2e-rbac-test-1
   specifications:
     - 'IamPolicy'
-  cluster_binding: []
+  cluster_binding: [] # skip cluster_binding selection if empty
   disable: True


### PR DESCRIPTION
Signed-off-by: Yu Cao <ycao@redhat.com>
The resource used in RBAC test shouldn't need to be applied to all managed clusters. This should help us seeing less often below canary issue.
To only apply policy to one managed cluster, just need to remove `cluster_binding` in config. see https://github.com/open-cluster-management/grc-ui/blob/rbac/tests/cypress/support/views.js#L214

closes https://github.com/open-cluster-management/backlog/issues/16744