### PR TITLE
backport scc template fix to 2.3

### DIFF
--- a/src-web/components/common/templates/spec-scc.yaml
+++ b/src-web/components/common/templates/spec-scc.yaml
@@ -32,7 +32,7 @@ replacements: # if user select this choice, the template variable names and valu
                 metadata:
                   annotations:
                     kubernetes.io/description: restricted denies access to all host features and requires pods to be run with a UID, and SELinux context that are allocated to the namespace.  This is the most restrictive SCC and it is used by default for authenticated users.
-                  name: restricted-scc
+                  name: restricted
                 allowHostDirVolumePlugin: false
                 allowHostIPC: false
                 allowHostNetwork: false
@@ -40,13 +40,10 @@ replacements: # if user select this choice, the template variable names and valu
                 allowHostPorts: false
                 allowPrivilegeEscalation: true
                 allowPrivilegedContainer: false
-                allowedCapabilities: []
-                defaultAddCapabilities: []
                 fsGroup:
                   type: MustRunAs
                 groups:
                 - system:authenticated
-                priority: 10
                 readOnlyRootFilesystem: false
                 requiredDropCapabilities:
                 - KILL

--- a/tests/cypress/config/SCC_policy_governance/SCC_cleanup_policy_raw.yaml
+++ b/tests/cypress/config/SCC_policy_governance/SCC_cleanup_policy_raw.yaml
@@ -30,7 +30,7 @@ spec:
               metadata:
                 annotations:
                   kubernetes.io/description: restricted denies access to all host features and requires pods to be run with a UID, and SELinux context that are allocated to the namespace.  This is the most restrictive SCC and it is used by default for authenticated users.
-                name: restricted-scc
+                name: restricted
               allowHostDirVolumePlugin: false
               allowHostIPC: false
               allowHostNetwork: false
@@ -38,13 +38,10 @@ spec:
               allowHostPorts: false
               allowPrivilegeEscalation: true
               allowPrivilegedContainer: false
-              allowedCapabilities: []
-              defaultAddCapabilities: []
               fsGroup:
                 type: MustRunAs
               groups:
               - system:authenticated
-              priority: 10
               readOnlyRootFilesystem: false
               requiredDropCapabilities:
               - KILL

--- a/tests/cypress/config/SCC_policy_governance/violations-inform.yaml
+++ b/tests/cypress/config/SCC_policy_governance/violations-inform.yaml
@@ -1,3 +1,3 @@
 "*":  # this is a default mapping
- - "[POLICYNAME]-restricted-scc-1"
+ - "[POLICYNAME]-restricted-scc-0"
 

--- a/tests/cypress/config/policy_YAML_templates_verification/SecurityContextConstraints-raw.yaml
+++ b/tests/cypress/config/policy_YAML_templates_verification/SecurityContextConstraints-raw.yaml
@@ -32,7 +32,7 @@ spec:
                 metadata:
                   annotations:
                     kubernetes.io/description: restricted denies access to all host features and requires pods to be run with a UID, and SELinux context that are allocated to the namespace.  This is the most restrictive SCC and it is used by default for authenticated users.
-                  name: restricted-scc
+                  name: restricted
                 allowHostDirVolumePlugin: false
                 allowHostIPC: false
                 allowHostNetwork: false
@@ -40,13 +40,10 @@ spec:
                 allowHostPorts: false
                 allowPrivilegeEscalation: true
                 allowPrivilegedContainer: false
-                allowedCapabilities: []
-                defaultAddCapabilities: []
                 fsGroup:
                   type: MustRunAs
                 groups:
                   - system:authenticated
-                priority: 10
                 readOnlyRootFilesystem: false
                 requiredDropCapabilities:
                   - KILL

--- a/tests/cypress/config/violation-patterns.yaml
+++ b/tests/cypress/config/violation-patterns.yaml
@@ -99,5 +99,5 @@ gatekeeper-operator-subscription:
 # SecurityContextConstraints specification
 [POLICYNAME]-restricted-scc:
  ?: "(notification|violation)"
- 0: "notification - securitycontextconstraints \\[restricted-scc\\] (was missing, and was created successfully|found as specified, therefore this Object template is compliant)"
- 1: "violation - securitycontextconstraints not found: \\[restricted-scc\\] missing"
+ 0: "notification - securitycontextconstraints \\[restricted\\] (was missing, and was created successfully|found as specified, therefore this Object template is compliant)"
+ 1: "violation - securitycontextconstraints not found: \\[restricted\\] missing"


### PR DESCRIPTION
Signed-off-by: Will Kutler <wkutler@redhat.com>

backports scc fixes from https://github.com/open-cluster-management/grc-ui/pull/782/files and https://github.com/open-cluster-management/grc-ui/pull/797

fixes https://github.com/open-cluster-management/backlog/issues/16207 in 2.3