### PR TITLE
remove breakPoint prop

### DIFF
--- a/src-web/components/modules/GrcToggleModule.js
+++ b/src-web/components/modules/GrcToggleModule.js
@@ -137,7 +137,6 @@ class GrcToggleModule extends React.Component {
               setSearch={this.handleSearch}
               sort={sortValues[grcTabToggleIndex]}
               setSort={this.setSort(grcTabToggleIndex)}
-              gridBreakPoint=''
               extraToolbarControls={extraToolbarControls}
               searchPlaceholder={msgs.get('tabs.grc.toggle.allPolicies.placeHolderText', locale)}
               fuseThreshold={0}

--- a/src-web/components/modules/PolicyStatusView.js
+++ b/src-web/components/modules/PolicyStatusView.js
@@ -61,7 +61,6 @@ class PolicyStatusView extends React.Component {
                 items={tableDataByClusters.rows}
                 columns={tableDataByClusters.columns}
                 keyFn={(item) => item.uid.toString()}
-                gridBreakPoint=''
                 search={clusterQuery}
                 setSearch={this.handleSearch}
                 initialSort={tableDataByClusters.sortBy}
@@ -86,7 +85,6 @@ class PolicyStatusView extends React.Component {
                   items={table.data.rows}
                   columns={table.data.columns}
                   keyFn={(item) => item.uid.toString()}
-                  gridBreakPoint=''
                   initialSort={table.data.sortBy}
                   searchPlaceholder={msgs.get('tabs.grc.toggle.clusterViolations.placeHolderText', locale)}
                   fuseThreshold={0}

--- a/src-web/components/modules/PolicyTemplateDetailsView.js
+++ b/src-web/components/modules/PolicyTemplateDetailsView.js
@@ -125,7 +125,6 @@ class PolicyTemplateDetailsView extends React.Component {
               items={tableData.rows}
               columns={tableData.columns}
               keyFn={(item) => item.uid.toString()}
-              gridBreakPoint=''
               initialSort={tableData.sortBy}
               plural={'related resources'}
             />

--- a/src-web/scss/grc-toggle-module.scss
+++ b/src-web/scss/grc-toggle-module.scss
@@ -31,6 +31,7 @@
 .pf-c-button.pf-m-link.automationButton {
   padding: 0px;
   font-size: 14px;
+  text-align: left;
 }
 
 .automationLabel {

--- a/src-web/scss/grc-toggle-module.scss
+++ b/src-web/scss/grc-toggle-module.scss
@@ -37,3 +37,11 @@
 .automationLabel {
   margin-right: 5px;
 }
+
+.pf-c-table{  
+  tbody.pf-m-expanded {
+    .pf-c-table__expandable-row.pf-m-expanded {
+      padding-bottom: 5px;
+    }
+  }
+}

--- a/src-web/scss/grc-toggle-module.scss
+++ b/src-web/scss/grc-toggle-module.scss
@@ -44,4 +44,7 @@
       padding-bottom: 5px;
     }
   }
+    .pf-c-label {
+    width: fit-content;
+  }
 }

--- a/src-web/tableDefinitions/utils.js
+++ b/src-web/tableDefinitions/utils.js
@@ -88,7 +88,6 @@ export const transform = (items, def, locale) => {
                   items={subRows}
                   columns={columns.colChild}
                   keyFn={keyFn}
-                  gridBreakPoint=''
                   showToolbar={false}
                   autoHidePagination
                   noBorders


### PR DESCRIPTION
Related Issue:https://github.com/open-cluster-management/backlog/issues/16902
Signed-off-by: rhowingt@redhat.com <rhowingt@redhat.com>

Now the row will transition into compact view instead of overflowing.

Larger width screen:
<kbd>![Screen Shot 2021-10-11 at 1 13 09 PM](https://user-images.githubusercontent.com/10394596/136829515-d1fdb3cb-1837-4dd9-9f93-4ac93c8bb1f6.png)</kbd>
Scaled down screen:
<kbd>
![Screen Shot 2021-10-11 at 1 13 21 PM](https://user-images.githubusercontent.com/10394596/136829546-6defa3d3-3069-472a-b341-0763d19620a6.png)
</kbd>