### PR TITLE
e2e testing scroll to automation modal bottom

### DIFF
--- a/tests/cypress/support/views.js
+++ b/tests/cypress/support/views.js
@@ -1570,7 +1570,7 @@ export const action_scheduleAutomation = (uName, credentialName, mode) => {
     })
   }
   //submit automation and check history page
-  cy.get('.pf-c-modal-box__footer').within(() => {
+  cy.get('.pf-c-modal-box__footer').scrollIntoView().within(() => {
       cy.waitUntil(() => cy.get('button').eq(0).scrollIntoView().should('be.visible'))
       cy.get('button').eq(0).scrollIntoView().should('be.visible').click()
     })


### PR DESCRIPTION
Signed-off-by: Chunxi Luo chuluo@redhat.com

https://github.com/open-cluster-management/backlog/issues/17051

https://app.travis-ci.com/github/open-cluster-management/canary/jobs/542469587#L918

Based on the log, it seems cypress can find the automation modal but can't find the modal footer, add  scrollIntoView() to see if fix this