### PR TITLE
Remove force click for action menu

### DIFF
--- a/tests/cypress/support/views.js
+++ b/tests/cypress/support/views.js
@@ -447,13 +447,9 @@ export const action_actionPolicyActionInListing = (uName, action, cancel=false) 
       .parents('td')
       .siblings('td')
       .last().within(() => {
-        cy.waitUntil(() => cy.get('button').scrollIntoView().should('be.visible'))
-        cy.get('button').scrollIntoView().should('be.visible').click({ force: true })
+        cy.get('button').scrollIntoView().should('be.visible').click()
+         .get('button').contains(action, { matchCase: false }).scrollIntoView().should('be.visible').click()
       })
-  })
-  .then(() => {
-    cy.waitUntil(() => cy.get('button').contains(action, { matchCase: false }).scrollIntoView().should('be.visible'))
-    cy.get('button').contains(action, { matchCase: false }).scrollIntoView().should('be.visible').click({ force: true })
   })
   .then(() => {
     cy.get('.pf-c-modal-box').within(() => {


### PR DESCRIPTION
Force-clicks sometimes don't actually click, as seen in screenshot. Chain the clicking of the submenu item off the click so that the chain can be retried until the buttons are actionable.

![image](https://user-images.githubusercontent.com/42188127/137943415-ae8eadcd-9899-43a7-b90c-de569ab0dfbc.png)

Signed-off-by: Kevin Cormier <kcormier@redhat.com>

https://github.com/open-cluster-management/backlog/issues/17341