### PR TITLE
Revert "Remove the PodSecurityPolicy sample GRC policy (#833)"

### DIFF
--- a/src-web/components/common/templates/index.js
+++ b/src-web/components/common/templates/index.js
@@ -20,6 +20,7 @@ import specGatekeeper from './spec-gatekeeper.yaml'
 import specImagemanifestvuln from './spec-imagemanifestvuln.yaml'
 import specNamespace from './spec-namespace.yaml'
 import specPodExists from './spec-pod-exists.yaml'
+import specPodSecurity from './spec-pod-security.yaml'
 import specRolebinding from './spec-rolebinding.yaml'
 import specRoles from './spec-roles.yaml'
 import specScc from './spec-scc.yaml'
@@ -34,6 +35,7 @@ const Choices = {
   specImagemanifestvuln,
   specNamespace,
   specPodExists,
+  specPodSecurity,
   specRolebinding,
   specRoles,
   specScc,

--- a/src-web/components/common/templates/spec-pod-security.yaml
+++ b/src-web/components/common/templates/spec-pod-security.yaml
@@ -1,0 +1,56 @@
+# an available choice for the specs control
+name:
+  PodSecurityPolicy
+description:
+  No privileged pods
+multiselect:
+  specs
+replacements: # if user select this choice, the template variable names and values to use
+  standards: |
+    NIST-CSF
+  categories: |
+    PR.PT Protective Technology
+  controls: |
+    PR.PT-3 Least Functionality
+  policyTemplates: |
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: {{name}}-restricted-psp
+        spec:
+          remediationAction: inform # will be overridden by remediationAction in parent policy
+          severity: high
+          namespaceSelector:
+            exclude: ["kube-*"]
+            include: ["default"]
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: policy/v1beta1
+                kind: PodSecurityPolicy # no privileged pods
+                metadata:
+                  name: restricted-psp
+                  annotations:
+                    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+                spec:
+                  privileged: false # no priviliedged pods
+                  allowPrivilegeEscalation: false
+                  allowedCapabilities:
+                  - '*'
+                  volumes:
+                  - '*'
+                  hostNetwork: true
+                  hostPorts:
+                  - min: 1000 # ports < 1000 are reserved
+                    max: 65535
+                  hostIPC: false
+                  hostPID: false
+                  runAsUser:
+                    rule: 'RunAsAny'
+                  seLinux:
+                    rule: 'RunAsAny'
+                  supplementalGroups:
+                    rule: 'RunAsAny'
+                  fsGroup:
+                    rule: 'RunAsAny'

--- a/tests/cypress/config/PodSecurityPolicy_governance/PodSecurityPolicy_cleanup_policy_raw.yaml
+++ b/tests/cypress/config/PodSecurityPolicy_governance/PodSecurityPolicy_cleanup_policy_raw.yaml
@@ -1,0 +1,81 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: pod-security-policy-cleanup-[ID]
+  namespace: default
+  annotations:
+    policy.open-cluster-management.io/standards: NIST-CSF
+    policy.open-cluster-management.io/categories: PR.PT Protective Technology
+    policy.open-cluster-management.io/controls: PR.PT-3 Least Functionality
+spec:
+  remediationAction: enforce
+  disabled: false
+  policy-templates:
+  - objectDefinition:
+      apiVersion: policy.open-cluster-management.io/v1
+      kind: ConfigurationPolicy
+      metadata:
+        name: pod-security-policy-cleanup-[ID]-restricted-psp
+      spec:
+        remediationAction: inform # will be overridden by remediationAction in parent policy
+        severity: high
+        namespaceSelector:
+          exclude: ["kube-*"]
+          include: ["default"]
+        object-templates:
+          - complianceType: mustnothave
+            objectDefinition:
+              apiVersion: policy/v1beta1
+              kind: PodSecurityPolicy # no privileged pods
+              metadata:
+                name: restricted-psp
+                annotations:
+                  seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+              spec:
+                privileged: false # no priviliedged pods
+                allowPrivilegeEscalation: false
+                allowedCapabilities:
+                - '*'
+                volumes:
+                - '*'
+                hostNetwork: true
+                hostPorts:
+                - min: 1000 # ports < 1000 are reserved
+                  max: 65535
+                hostIPC: false
+                hostPID: false
+                runAsUser:
+                  rule: 'RunAsAny'
+                seLinux:
+                  rule: 'RunAsAny'
+                supplementalGroups:
+                  rule: 'RunAsAny'
+                fsGroup:
+                  rule: 'RunAsAny'
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: binding-pod-security-policy-cleanup-[ID]
+  namespace: default
+placementRef:
+  name: placement-pod-security-policy-cleanup-[ID]
+  kind: PlacementRule
+  apiGroup: apps.open-cluster-management.io
+subjects:
+- name: pod-security-policy-cleanup-[ID]
+  kind: Policy
+  apiGroup: policy.open-cluster-management.io
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: placement-pod-security-policy-cleanup-[ID]
+  namespace: default
+spec:
+  clusterConditions:
+  - status: "True"
+    type: ManagedClusterConditionAvailable
+  clusterSelector:
+    matchExpressions:
+      [LABEL]

--- a/tests/cypress/config/PodSecurityPolicy_governance/policy-config.yaml
+++ b/tests/cypress/config/PodSecurityPolicy_governance/policy-config.yaml
@@ -1,0 +1,22 @@
+test-pod-security-policy-[ID]:
+  apiVersion: 'policy.open-cluster-management.io/v1'
+  namespace: 'default'
+#  cluster_binding:
+#    - 'name: "dhaks1020-2-dho-461"'
+#    - 'local-cluster: "true"'
+  # binding_selector:
+    # - 'matchExpressions =[]'
+#    - 'matchExpressions =[ { "key": "name", "operator": "In", "values": [ "dhaks1020-2-dho-461" ] } ]'
+#    - 'matchExpressions =[ { "key": "local-cluster", "operator": "In", "values": [ "true" ] } ]'
+  kind: 'ConfigurationPolicy'
+  specifications:
+    - 'PodSecurityPolicy'
+  standards:
+    - 'NIST-CSF'
+  categories:
+    - 'PR.PT Protective Technology'
+  controls:
+    - 'PR.PT-3 Least Functionality'
+  remediation: False
+  disable: 
+

--- a/tests/cypress/config/PodSecurityPolicy_governance/violations-enforce.yaml
+++ b/tests/cypress/config/PodSecurityPolicy_governance/violations-enforce.yaml
@@ -1,0 +1,3 @@
+"*": # this is the default mapping
+ - "[POLICYNAME]-restricted-psp-0"
+

--- a/tests/cypress/config/PodSecurityPolicy_governance/violations-inform.yaml
+++ b/tests/cypress/config/PodSecurityPolicy_governance/violations-inform.yaml
@@ -1,0 +1,3 @@
+"*":  # this is a default mapping
+ - "[POLICYNAME]-restricted-psp-1"
+

--- a/tests/cypress/config/policy_YAML_templates_verification/PodSecurityPolicy-raw.yaml
+++ b/tests/cypress/config/policy_YAML_templates_verification/PodSecurityPolicy-raw.yaml
@@ -1,0 +1,86 @@
+apiVersion: policy.open-cluster-management.io/v1
+kind: Policy
+metadata:
+  name: podsecuritypolicy
+  namespace: default
+  annotations:
+    policy.open-cluster-management.io/standards: NIST-CSF
+    policy.open-cluster-management.io/categories: PR.PT Protective Technology
+    policy.open-cluster-management.io/controls: PR.PT-3 Least Functionality
+spec:
+  remediationAction: inform
+  disabled: false
+  policy-templates:
+    - objectDefinition:
+        apiVersion: policy.open-cluster-management.io/v1
+        kind: ConfigurationPolicy
+        metadata:
+          name: podsecuritypolicy-restricted-psp
+        spec:
+          remediationAction: inform
+          severity: high
+          namespaceSelector:
+            exclude:
+              - kube-*
+            include:
+              - default
+          object-templates:
+            - complianceType: musthave
+              objectDefinition:
+                apiVersion: policy/v1beta1
+                kind: PodSecurityPolicy
+                metadata:
+                  name: restricted-psp
+                  annotations:
+                    seccomp.security.alpha.kubernetes.io/allowedProfileNames: '*'
+                spec:
+                  privileged: false
+                  allowPrivilegeEscalation: false
+                  allowedCapabilities:
+                    - '*'
+                  volumes:
+                    - '*'
+                  hostNetwork: true
+                  hostPorts:
+                    - min: 1000
+                      max: 65535
+                  hostIPC: false
+                  hostPID: false
+                  runAsUser:
+                    rule: RunAsAny
+                  seLinux:
+                    rule: RunAsAny
+                  supplementalGroups:
+                    rule: RunAsAny
+                  fsGroup:
+                    rule: RunAsAny
+---
+apiVersion: policy.open-cluster-management.io/v1
+kind: PlacementBinding
+metadata:
+  name: binding-podsecuritypolicy
+  namespace: default
+placementRef:
+  name: placement-podsecuritypolicy
+  kind: PlacementRule
+  apiGroup: apps.open-cluster-management.io
+subjects:
+  - name: podsecuritypolicy
+    kind: Policy
+    apiGroup: policy.open-cluster-management.io
+---
+apiVersion: apps.open-cluster-management.io/v1
+kind: PlacementRule
+metadata:
+  name: placement-podsecuritypolicy
+  namespace: default
+spec:
+  clusterConditions:
+    - status: 'True'
+      type: ManagedClusterConditionAvailable
+  clusterSelector:
+    matchExpressions:
+      - key: local-cluster
+        operator: In
+        values:
+          - 'true'

--- a/tests/cypress/config/policy_YAML_templates_verification/policy-config.yaml
+++ b/tests/cypress/config/policy_YAML_templates_verification/policy-config.yaml
@@ -79,6 +79,15 @@ Pod:
   remediation: False
   disable: False
 
+PodSecurityPolicy:
+  namespace: 'default'
+  cluster_binding:
+   - 'local-cluster: "true"'
+  specifications:
+    - 'PodSecurityPolicy'
+  remediation: False
+  disable: False
+
 Role:
   namespace: 'default'
   cluster_binding:

--- a/tests/cypress/config/violation-patterns.yaml
+++ b/tests/cypress/config/violation-patterns.yaml
@@ -81,6 +81,11 @@ gatekeeper-operator-subscription:
  0: "notification - pods \\[nginx-pod\\] in namespace [NAMESPACE] (was missing, and was created successfully|found as specified, therefore this Object template is compliant)"
  1: "violation - pods not found: \\[nginx-pod\\] in namespace [NAMESPACE] missing"
  2: "violation - namespaced object has no namespace specified"
+# PodSecurityPolicy specification
+[POLICYNAME]-restricted-psp:
+ ?: "(notification|violation)"
+ 0: "notification - podsecuritypolicies \\[restricted-psp\\] (was missing, and was created successfully|found as specified, therefore this Object template is compliant)"
+ 1: "violation - podsecuritypolicies not found: \\[restricted-psp\\] missing"
 # Role specification
 [POLICYNAME]-deployments-role:
  ?: "(notification|violation)"

--- a/tests/cypress/support/views.js
+++ b/tests/cypress/support/views.js
@@ -772,6 +772,9 @@ export const getPolicyTemplatesNameAndKind = (policyName, policyConfig) => {
     case 'Pod':
       templates.add(policyName+'-nginx-pod'+'/'+'ConfigurationPolicy')
       break
+    case 'PodSecurityPolicy':
+      templates.add(policyName+'-restricted-psp'+'/'+'ConfigurationPolicy')
+      break
     case 'Role':
       templates.add(policyName+'-deployments-role'+'/'+'ConfigurationPolicy')
       break

--- a/tests/cypress/tests/PodSecurityPolicy_governance.spec.js
+++ b/tests/cypress/tests/PodSecurityPolicy_governance.spec.js
@@ -1,0 +1,14 @@
+/* Copyright (c) 2020 Red Hat, Inc. */
+/* Copyright Contributors to the Open Cluster Management project */
+
+/// <reference types="cypress" />
+import { describeT } from '../support/tagging'
+import { test_genericPolicyGovernance, test_applyPolicyYAML } from '../support/tests'
+
+describeT('@extended RHACM4K-1720 - GRC UI: [P1][Sev1][console] PodSecurityPolicy governance', () => {
+  test_genericPolicyGovernance('PodSecurityPolicy_governance/policy-config.yaml', 'PodSecurityPolicy_governance/violations-inform.yaml', 'PodSecurityPolicy_governance/violations-enforce.yaml')
+})
+
+describeT('@extended GRC UI: [P1][Sev1][console] PodSecurityPolicy governance - clean up', () => {
+  test_applyPolicyYAML('PodSecurityPolicy_governance/PodSecurityPolicy_cleanup_policy_raw.yaml')
+})

--- a/tests/jest/components/common/TemplateEditor/TemplateEditor.test.js
+++ b/tests/jest/components/common/TemplateEditor/TemplateEditor.test.js
@@ -74,6 +74,7 @@ const controlData = [
       'LimitRange - limit memory usage',
       'Namespace - must have namespace \'prod\'',
       'Pod - nginx pod must exist',
+      'PodSecurityPolicy - no privileged pods',
       'Role - role must follow defined permissions',
       'RoleBinding - role binding must exist',
       'SecurityContextConstraints - restricted scc'


### PR DESCRIPTION
This reverts commit fda831dc5bc48dd56368f5634e99f6e3be4786e1. This stems
from @berenss's decision in:
https://github.com/open-cluster-management/policy-collection/pull/171#issuecomment-953988183

Signed-off-by: mprahl <mprahl@users.noreply.github.com>